### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Three families are always present: `monitor`, `mysql`, and `proxy`. Each family 
 "configuration_connection": {
   "name": "connections",
   "parameters": {
-    "binlog_cache_size": { "name": "binlog_cache_size", "value": "131072", "default": "32768", "min": 4096, "max": 16777216 },
-    "join_buffer_size": { "name": "join_buffer_size", "value": "524288", "default": "262144", "min": 128, "max": 4294967295 }
+    "binlog_cache_size": { "name": "binlog_cache_size", "value": "131072" },
+    "join_buffer_size": { "name": "join_buffer_size", "value": "524288" }
   }
 }
 ```
-*Note: The `value` field is the calculated number you should use in your deployments. `default`, `min`, and `max` are provided for bounds checking.*
+*Note: The `value` field is the calculated number you should use in your deployments.*
 
 > **⚠️ Critical Warning on Probes and Limits:**
 > The `livenessProbe`, `readinessProbe`, and `resources` (CPU/Memory limits) groups are **not optional**. Ignoring the generated resource limits or probe timings will almost certainly cause unnecessary pod restarts or OOM kills under load.
@@ -571,7 +571,7 @@ The JSON response is divided into three main blocks: `message` (diagnostic statu
 
 ### 2. Human-Readable Output (`"output": "human"`)
 
-The human-readable format strips away the structural metadata and boundary limits (`min`, `max`, `default`), outputting flat, INI-style blocks. This is particularly useful for quickly pasting into a `my.cnf` file or reviewing the raw numbers.
+The human-readable format strips away the structural metadata, outputting flat, INI-style blocks. This is particularly useful for quickly pasting into a `my.cnf` file or reviewing the raw numbers.
 
 ```ini
 --- MESSAGE ---

--- a/src/help.go
+++ b/src/help.go
@@ -33,7 +33,7 @@ func (help *HelpText) PrintLicense() {
 }
 
 func (help *HelpText) GetHelpText() string {
-	helpText := `PXC Calculator for Percona Operator
+	helpText := `MySQL Calculator for Percona Operator (PXC and PS)
 
 
 To get supported scenarios:

--- a/src/mysqloperatorcalculator/Configuration.go
+++ b/src/mysqloperatorcalculator/Configuration.go
@@ -10,103 +10,104 @@ import (
 	"code.cloudfoundry.org/bytefmt"
 )
 
-// ***********************************
-// Constants
-// ***********************************
-const (
-	VERSION = "v1.11.0"
-
-	OkI                    = 1001
-	ClosetolimitI          = 2001
-	OverutilizingI         = 3001
-	ErrorexecI             = 5001
-	ConnectionRecalculated = 6001
-	ResourcesRecalculated  = 7001
-
-	OkT                       = "Execution was successful and resources match the possible requests"
-	ClosetolimitT             = "Execution was successful however resources are close to saturation based on the load requested"
-	OverutilizingT            = "Resources not enough to cover the requested load "
-	ErrorexecT                = "There is an error while processing. See details: %s"
-	ConnectionRecalculatedTxt = "The number of connection has been recalculated to match the available resources"
-	ResourcesRecalculatedTxt  = "All resources have been recalculated to match the requested connections"
-
-	LoadTypeMostlyReads      = 1
-	LoadTypeSomeWrites       = 2
-	LoadTypeEqualReadsWrites = 3
-	LoadTypeHeavyWrites      = 4
-
-	DimensionOpen       = 999
-	ConnectionDimension = 998
-
-	FamilyTypeMysql   = "mysql"
-	FamilyTypeProxy   = "proxy"
-	FamilyTypeMonitor = "monitor"
-
-	GroupNameMySQLd    = "mysqld"
-	GroupNameProbes    = "probes"
-	GroupNameResources = "resources"
-	GroupNameHAProxy   = "haproxyConfig"
-
-	DbTypePXC              = "pxc"
-	DbTypeGroupReplication = "group_replication"
-
-	ResultOutputFormatJson  = "json"
-	ResultOutputFormatHuman = "human"
-
-	InnoDBPctValuePXC = 0.80
-	InnoDBPctValueGR  = 0.70
-
-	GroupRepGCSCacheMemStructureCost = 52428800
-
-	MinLimitPXC            = 0.50
-	MinLimitGR             = 0.40
-	MemoryFreeMinimumLimit = 0.02
-
-	/* Minlimit is the % of memory assigned to Innodb buffer pool compared to the total memory assigned to mysql
-	We have different min limit per type of replication (galera and Group replication) because the different impact of the internal cache.
-	In GR the certification cache is suffering of an issue. In short the certification cache is clean/flushed on commit, but if the operation is a long one like insert into A from select * from b ;
-	and we have large dataset, this may cause the cache buffer to be very large and causing issues like swap or OOM kill.
-	While we cannot prevent this to happen, we need to consider the possible impact of it.
-	Also other caches used by GR and more frequently cleanup are causing higher memory consumption than galera.
-	as such we need to allocate less memory to innodb and more to buffers.
-	By consequence the % of innodb memory for galera is higher than GR
-	*/
-	// MemoryFreeMinimumLimit This is the amount of memory in % that we must keep free no matter what to give some space to the server
-
-	// Weight to use when using PXC for Gcache in mem footprint
-	GcacheFootPrintFactorRead       = 0.5
-	GcacheFootPrintFactorLightWrite = 0.6
-	GcacheFootPrintFactorReadWrite  = 0.8
-
-	// Weights to use to tune the GCS calculation against connections
-	GCSConnWeight = 10 //each connection costs 10 millicycles
-	// TODO Deprecated
-	//GCSWeightRead           = 0.40
-	//GCSWeightReadLightWrite = 0.60
-	//GCSWeightReadWrite      = 1.20
-	//GCSWeightReadHeavyWrite = 1
-
-	CPUIncrement    = 200
-	MemoryIncrement = 500
-
-	CpuConncetionMillFactorRead           = 0.8
-	CpuConncetionMillFactorReadWriteLight = 1.2
-	CpuConncetionMillFactorReadWriteEqual = 1.6
-	CpuConncetionMillFactorReadWriteHeavy = 2
-
-	ConnectionWeighPctLimit = 0.50
-	MinConnectionNumber     = 20
-
-	/*Connection / CPU adjustment factor this is the factor by which we divide the available CPU mill reporting th emaximum number of connections available
-	if we assign 2000 CPU and ask for 100 connection the formula will be CPUmill/CpuConncetionMillFactor < Connection asked
-	if the number of CPUmill/CpuConncetionMillFactor > Connection asked we are overloading the platform
-	We hace 3 different load factors:
-	- mainly read
-	- read/write 80/20
-	- read/write 50/50
-	*/
-	// Global
-)
+//
+//// ***********************************
+//// Constants
+//// ***********************************
+//const (
+//	VERSION = "v1.11.0"
+//
+//	OkI                    = 1001
+//	ClosetolimitI          = 2001
+//	OverutilizingI         = 3001
+//	ErrorexecI             = 5001
+//	ConnectionRecalculated = 6001
+//	ResourcesRecalculated  = 7001
+//
+//	OkT                       = "Execution was successful and resources match the possible requests"
+//	ClosetolimitT             = "Execution was successful however resources are close to saturation based on the load requested"
+//	OverutilizingT            = "Resources not enough to cover the requested load "
+//	ErrorexecT                = "There is an error while processing. See details: %s"
+//	ConnectionRecalculatedTxt = "The number of connection has been recalculated to match the available resources"
+//	ResourcesRecalculatedTxt  = "Minimum resource estimates have been updated to correspond with the specified connection count."
+//
+//	LoadTypeMostlyReads      = 1
+//	LoadTypeSomeWrites       = 2
+//	LoadTypeEqualReadsWrites = 3
+//	LoadTypeHeavyWrites      = 4
+//
+//	DimensionOpen       = 999
+//	ConnectionDimension = 998
+//
+//	FamilyTypeMysql   = "mysql"
+//	FamilyTypeProxy   = "proxy"
+//	FamilyTypeMonitor = "monitor"
+//
+//	GroupNameMySQLd    = "mysqld"
+//	GroupNameProbes    = "probes"
+//	GroupNameResources = "resources"
+//	GroupNameHAProxy   = "haproxyConfig"
+//
+//	DbTypePXC              = "pxc"
+//	DbTypeGroupReplication = "group_replication"
+//
+//	ResultOutputFormatJson  = "json"
+//	ResultOutputFormatHuman = "human"
+//
+//	InnoDBPctValuePXC = 0.80
+//	InnoDBPctValueGR  = 0.70
+//
+//	GroupRepGCSCacheMemStructureCost = 52428800
+//
+//	MinLimitPXC            = 0.50
+//	MinLimitGR             = 0.40
+//	MemoryFreeMinimumLimit = 0.02
+//
+//	/* Minlimit is the % of memory assigned to Innodb buffer pool compared to the total memory assigned to mysql
+//	We have different min limit per type of replication (galera and Group replication) because the different impact of the internal cache.
+//	In GR the certification cache is suffering of an issue. In short the certification cache is clean/flushed on commit, but if the operation is a long one like insert into A from select * from b ;
+//	and we have large dataset, this may cause the cache buffer to be very large and causing issues like swap or OOM kill.
+//	While we cannot prevent this to happen, we need to consider the possible impact of it.
+//	Also other caches used by GR and more frequently cleanup are causing higher memory consumption than galera.
+//	as such we need to allocate less memory to innodb and more to buffers.
+//	By consequence the % of innodb memory for galera is higher than GR
+//	*/
+//	// MemoryFreeMinimumLimit This is the amount of memory in % that we must keep free no matter what to give some space to the server
+//
+//	// Weight to use when using PXC for Gcache in mem footprint
+//	GcacheFootPrintFactorRead       = 0.5
+//	GcacheFootPrintFactorLightWrite = 0.6
+//	GcacheFootPrintFactorReadWrite  = 0.8
+//
+//	// Weights to use to tune the GCS calculation against connections
+//	GCSConnWeight = 10 //each connection costs 10 millicycles
+//	// TODO Deprecated
+//	//GCSWeightRead           = 0.40
+//	//GCSWeightReadLightWrite = 0.60
+//	//GCSWeightReadWrite      = 1.20
+//	//GCSWeightReadHeavyWrite = 1
+//
+//	CPUIncrement    = 200
+//	MemoryIncrement = 500
+//
+//	CpuConncetionMillFactorRead           = 0.8
+//	CpuConncetionMillFactorReadWriteLight = 1.2
+//	CpuConncetionMillFactorReadWriteEqual = 1.6
+//	CpuConncetionMillFactorReadWriteHeavy = 2
+//
+//	ConnectionWeighPctLimit = 0.50
+//	MinConnectionNumber     = 20
+//
+//	/*Connection / CPU adjustment factor this is the factor by which we divide the available CPU mill reporting th emaximum number of connections available
+//	if we assign 2000 CPU and ask for 100 connection the formula will be CPUmill/CpuConncetionMillFactor < Connection asked
+//	if the number of CPUmill/CpuConncetionMillFactor > Connection asked we are overloading the platform
+//	We hace 3 different load factors:
+//	- mainly read
+//	- read/write 80/20
+//	- read/write 50/50
+//	*/
+//	// Global
+//)
 
 //*********************************
 // Structure definitions

--- a/src/mysqloperatorcalculator/Configuration.go
+++ b/src/mysqloperatorcalculator/Configuration.go
@@ -10,104 +10,19 @@ import (
 	"code.cloudfoundry.org/bytefmt"
 )
 
-//
-//// ***********************************
-//// Constants
-//// ***********************************
-//const (
-//	VERSION = "v1.11.0"
-//
-//	OkI                    = 1001
-//	ClosetolimitI          = 2001
-//	OverutilizingI         = 3001
-//	ErrorexecI             = 5001
-//	ConnectionRecalculated = 6001
-//	ResourcesRecalculated  = 7001
-//
-//	OkT                       = "Execution was successful and resources match the possible requests"
-//	ClosetolimitT             = "Execution was successful however resources are close to saturation based on the load requested"
-//	OverutilizingT            = "Resources not enough to cover the requested load "
-//	ErrorexecT                = "There is an error while processing. See details: %s"
-//	ConnectionRecalculatedTxt = "The number of connection has been recalculated to match the available resources"
-//	ResourcesRecalculatedTxt  = "Minimum resource estimates have been updated to correspond with the specified connection count."
-//
-//	LoadTypeMostlyReads      = 1
-//	LoadTypeSomeWrites       = 2
-//	LoadTypeEqualReadsWrites = 3
-//	LoadTypeHeavyWrites      = 4
-//
-//	DimensionOpen       = 999
-//	ConnectionDimension = 998
-//
-//	FamilyTypeMysql   = "mysql"
-//	FamilyTypeProxy   = "proxy"
-//	FamilyTypeMonitor = "monitor"
-//
-//	GroupNameMySQLd    = "mysqld"
-//	GroupNameProbes    = "probes"
-//	GroupNameResources = "resources"
-//	GroupNameHAProxy   = "haproxyConfig"
-//
-//	DbTypePXC              = "pxc"
-//	DbTypeGroupReplication = "group_replication"
-//
-//	ResultOutputFormatJson  = "json"
-//	ResultOutputFormatHuman = "human"
-//
-//	InnoDBPctValuePXC = 0.80
-//	InnoDBPctValueGR  = 0.70
-//
-//	GroupRepGCSCacheMemStructureCost = 52428800
-//
-//	MinLimitPXC            = 0.50
-//	MinLimitGR             = 0.40
-//	MemoryFreeMinimumLimit = 0.02
-//
-//	/* Minlimit is the % of memory assigned to Innodb buffer pool compared to the total memory assigned to mysql
-//	We have different min limit per type of replication (galera and Group replication) because the different impact of the internal cache.
-//	In GR the certification cache is suffering of an issue. In short the certification cache is clean/flushed on commit, but if the operation is a long one like insert into A from select * from b ;
-//	and we have large dataset, this may cause the cache buffer to be very large and causing issues like swap or OOM kill.
-//	While we cannot prevent this to happen, we need to consider the possible impact of it.
-//	Also other caches used by GR and more frequently cleanup are causing higher memory consumption than galera.
-//	as such we need to allocate less memory to innodb and more to buffers.
-//	By consequence the % of innodb memory for galera is higher than GR
-//	*/
-//	// MemoryFreeMinimumLimit This is the amount of memory in % that we must keep free no matter what to give some space to the server
-//
-//	// Weight to use when using PXC for Gcache in mem footprint
-//	GcacheFootPrintFactorRead       = 0.5
-//	GcacheFootPrintFactorLightWrite = 0.6
-//	GcacheFootPrintFactorReadWrite  = 0.8
-//
-//	// Weights to use to tune the GCS calculation against connections
-//	GCSConnWeight = 10 //each connection costs 10 millicycles
-//	// TODO Deprecated
-//	//GCSWeightRead           = 0.40
-//	//GCSWeightReadLightWrite = 0.60
-//	//GCSWeightReadWrite      = 1.20
-//	//GCSWeightReadHeavyWrite = 1
-//
-//	CPUIncrement    = 200
-//	MemoryIncrement = 500
-//
-//	CpuConncetionMillFactorRead           = 0.8
-//	CpuConncetionMillFactorReadWriteLight = 1.2
-//	CpuConncetionMillFactorReadWriteEqual = 1.6
-//	CpuConncetionMillFactorReadWriteHeavy = 2
-//
-//	ConnectionWeighPctLimit = 0.50
-//	MinConnectionNumber     = 20
-//
-//	/*Connection / CPU adjustment factor this is the factor by which we divide the available CPU mill reporting th emaximum number of connections available
-//	if we assign 2000 CPU and ask for 100 connection the formula will be CPUmill/CpuConncetionMillFactor < Connection asked
-//	if the number of CPUmill/CpuConncetionMillFactor > Connection asked we are overloading the platform
-//	We hace 3 different load factors:
-//	- mainly read
-//	- read/write 80/20
-//	- read/write 50/50
-//	*/
-//	// Global
-//)
+//*********************************
+// Version definitions
+//********************************
+
+var MySQLMinSupported = Version{8, 0, 46}
+var MySQLMaxSupported = Version{11, 1, 1}
+
+// Boundary points where behaviour changed
+var V8_0_46 = Version{8, 0, 46}
+var V8_4_1 = Version{8, 4, 1}
+var V11_1_1 = Version{11, 1, 1}
+
+//********************************
 
 //*********************************
 // Structure definitions
@@ -271,74 +186,74 @@ func (conf *Configuration) Init() {
 func (family *Family) Init(DBTypeRequest string) map[string]Family {
 	// Group declarations shortened for brevity, functionally identical
 	replicaGroup := map[string]Parameter{
-		"replica_compressed_protocol":   {"replica_compressed_protocol", "configuration", "replication", "1", "1", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{9, 7, 0}}},
-		"replica_exec_mode":             {"replica_exec_mode", "configuration", "replication", "STRICT", "STRICT", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{9, 7, 0}}},
-		"replica_parallel_type":         {"replica_parallel_type", "configuration", "replication", "LOGICAL_CLOCK", "LOGICAL_CLOCK", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{9, 7, 0}}},
-		"replica_parallel_workers":      {"replica_parallel_workers", "configuration", "replication", "4", "4", 0, 1024, MySQLVersions{Version{8, 0, 30}, Version{9, 7, 0}}},
-		"replica_preserve_commit_order": {"replica_preserve_commit_order", "configuration", "replication", "ON", "ON", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{9, 7, 0}}},
+		"replica_compressed_protocol":   {"replica_compressed_protocol", "configuration", "replication", "1", "1", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
+		"replica_exec_mode":             {"replica_exec_mode", "configuration", "replication", "STRICT", "STRICT", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"replica_parallel_type":         {"replica_parallel_type", "configuration", "replication", "LOGICAL_CLOCK", "LOGICAL_CLOCK", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"replica_parallel_workers":      {"replica_parallel_workers", "configuration", "replication", "4", "4", 0, 1024, MySQLVersions{V8_0_46, V11_1_1}},
+		"replica_preserve_commit_order": {"replica_preserve_commit_order", "configuration", "replication", "ON", "ON", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
 	}
 	connectionGroup := map[string]Parameter{
-		//"binlog_cache_size":      {"binlog_cache_size", "configuration", "connection", "32768", "32768", 32768, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"binlog_stmt_cache_size": {"binlog_stmt_cache_size", "configuration", "connection", "32768", "32768", 32768, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"join_buffer_size":     {"join_buffer_size", "configuration", "connection", "262144", "262144", 262144, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"read_rnd_buffer_size": {"read_rnd_buffer_size", "configuration", "connection", "262144", "262144", 262144, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"sort_buffer_size":     {"sort_buffer_size", "configuration", "connection", "524288", "524288", 524288, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"max_heap_table_size":  {"max_heap_table_size", "configuration", "connection", "16777216", "16777216", 16777216, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"tmp_table_size":       {"tmp_table_size", "configuration", "connection", "16777216", "16777216", 16777216, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
+		//"binlog_cache_size":      {"binlog_cache_size", "configuration", "connection", "32768", "32768", 32768, 0, MySQLVersions{V8_0_46, Version{10, 1, 0}}},
+		//"binlog_stmt_cache_size": {"binlog_stmt_cache_size", "configuration", "connection", "32768", "32768", 32768, 0, MySQLVersions{V8_0_46, Version{10, 1, 0}}},
+		"join_buffer_size":     {"join_buffer_size", "configuration", "connection", "262144", "262144", 262144, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"read_rnd_buffer_size": {"read_rnd_buffer_size", "configuration", "connection", "262144", "262144", 262144, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"sort_buffer_size":     {"sort_buffer_size", "configuration", "connection", "524288", "524288", 524288, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"max_heap_table_size":  {"max_heap_table_size", "configuration", "connection", "16777216", "16777216", 16777216, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"tmp_table_size":       {"tmp_table_size", "configuration", "connection", "16777216", "16777216", 16777216, 0, MySQLVersions{V8_0_46, V11_1_1}},
 	}
 	serverGroup := map[string]Parameter{
-		"max_connections": {"max_connections", "configuration", "server", "50", "2", 2, 65536, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"table_definition_cache":            {"table_definition_cache", "configuration", "server", "4096", "4096", 400, 524288, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"table_open_cache":                  {"table_open_cache", "configuration", "server", "4096", "4096", 400, 524288, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"thread_stack":                      {"thread_stack", "configuration", "server", "1048576", "1048576", 131072, 393216, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"table_open_cache_instances":        {"table_open_cache_instances", "configuration", "server", "4", "16", 1, 64, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"tablespace_definition_cache":       {"tablespace_definition_cache", "configuration", "server", "512", "256", 256, 524288, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"sync_binlog": {"sync_binlog", "configuration", "server", "1", "1", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"sql_mode":    {"sql_mode", "configuration", "server", "'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,TRADITIONAL,STRICT_ALL_TABLES'", "0", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"binlog_expire_logs_seconds":        {"binlog_expire_logs_seconds", "configuration", "server", "604800", "0", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"binlog_format":                     {"binlog_format", "configuration", "server", "ROW", "0", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"thread_cache_size": {"thread_cache_size", "configuration", "server", "8", "8", 4, 16384, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"global-connection-memory-limit":    {"global_connection_memory_limit", "configuration", "server", "18446744073709551615", "16777216", 4, 18446744073709551615, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"global-connection-memory-tracking": {"global_connection_memory_tracking", "configuration", "server", "false", "false", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
+		"max_connections": {"max_connections", "configuration", "server", "50", "2", 2, 65536, MySQLVersions{V8_0_46, V11_1_1}},
+		//"table_definition_cache":            {"table_definition_cache", "configuration", "server", "4096", "4096", 400, 524288, MySQLVersions{V8_0_46, V11_1_1}},
+		//"table_open_cache":                  {"table_open_cache", "configuration", "server", "4096", "4096", 400, 524288, MySQLVersions{V8_0_46, V11_1_1}},
+		//"thread_stack":                      {"thread_stack", "configuration", "server", "1048576", "1048576", 131072, 393216, MySQLVersions{V8_0_46, V11_1_1}},
+		//"table_open_cache_instances":        {"table_open_cache_instances", "configuration", "server", "4", "16", 1, 64, MySQLVersions{V8_0_46, V11_1_1}},
+		//"tablespace_definition_cache":       {"tablespace_definition_cache", "configuration", "server", "512", "256", 256, 524288, MySQLVersions{V8_0_46, V11_1_1}},
+		"sync_binlog": {"sync_binlog", "configuration", "server", "1", "1", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
+		//"sql_mode":    {"sql_mode", "configuration", "server", "'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,TRADITIONAL,STRICT_ALL_TABLES'", "0", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
+		//"binlog_expire_logs_seconds":        {"binlog_expire_logs_seconds", "configuration", "server", "604800", "0", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		//"binlog_format":                     {"binlog_format", "configuration", "server", "ROW", "0", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"thread_cache_size": {"thread_cache_size", "configuration", "server", "8", "8", 4, 16384, MySQLVersions{V8_0_46, V11_1_1}},
+		//"global-connection-memory-limit":    {"global_connection_memory_limit", "configuration", "server", "18446744073709551615", "16777216", 4, 18446744073709551615, MySQLVersions{V8_0_46, V11_1_1}},
+		//"global-connection-memory-tracking": {"global_connection_memory_tracking", "configuration", "server", "false", "false", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
 	}
 	innodbGroup := map[string]Parameter{
-		"innodb_adaptive_hash_index": {"innodb_adaptive_hash_index", "configuration", "innodb", "0", "0", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_buffer_pool_size":    {"innodb_buffer_pool_size", "configuration", "innodb", "1073741824", "134217728", 5242880, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"innodb_ddl_threads":             {"innodb_ddl_threads", "configuration", "innodb", "2", "4", 1, 64, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_buffer_pool_instances":   {"innodb_buffer_pool_instances", "configuration", "innodb", "1", "8", 1, 64, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_flush_method":            {"innodb_flush_method", "configuration", "innodb", "O_DIRECT", "O_DIRECT", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_flush_log_at_trx_commit": {"innodb_flush_log_at_trx_commit", "configuration", "innodb", "2", "1", 0, 2, MySQLVersions{Version{8, 0, 30}, Version{10, 2, 0}}},
-		"innodb_log_file_size":           {"innodb_log_file_size", "configuration", "innodb", "119537664", "50331648", 4194304, 0, MySQLVersions{Version{8, 0, 27}, Version{8, 0, 30}}},
-		"innodb_log_files_in_group":      {"innodb_log_files_in_group", "configuration", "innodb", "2", "2", 2, 100, MySQLVersions{Version{8, 0, 27}, Version{8, 0, 30}}},
-		"innodb_redo_log_capacity":       {"innodb_redo_log_capacity", "configuration", "innodb", "119537664", "104857600", 8388608, 137438953472, MySQLVersions{Version{8, 0, 31}, Version{10, 1, 0}}},
-		//"innodb_page_cleaners":           {"innodb_page_cleaners", "configuration", "innodb", "1", "4", 1, 64, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_purge_threads":          {"innodb_purge_threads", "configuration", "innodb", "1", "4", 1, 32, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_io_capacity_max":        {"innodb_io_capacity_max", "configuration", "innodb", "20000", "20000", 100, 0, MySQLVersions{Version{8, 0, 30}, Version{8, 8, 0}}},
-		"innodb_numa_interleave":        {"innodb_numa_interleave", "configuration", "innodb", "0", "1", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{8, 8, 0}}},
-		"innodb_buffer_pool_chunk_size": {"innodb_buffer_pool_chunk_size", "configuration", "innodb", "2097152", "134217728", 1048576, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_parallel_read_threads":  {"innodb_parallel_read_threads", "configuration", "innodb", "1", "4", 1, 256, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"innodb_monitor_enable":         {"innodb_monitor_enable", "configuration", "innodb", "ALL", "ALL", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
+		"innodb_adaptive_hash_index": {"innodb_adaptive_hash_index", "configuration", "innodb", "0", "0", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_buffer_pool_size":    {"innodb_buffer_pool_size", "configuration", "innodb", "1073741824", "134217728", 5242880, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		//"innodb_ddl_threads":             {"innodb_ddl_threads", "configuration", "innodb", "2", "4", 1, 64, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_buffer_pool_instances":   {"innodb_buffer_pool_instances", "configuration", "innodb", "1", "8", 1, 64, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_flush_method":            {"innodb_flush_method", "configuration", "innodb", "O_DIRECT", "O_DIRECT", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_flush_log_at_trx_commit": {"innodb_flush_log_at_trx_commit", "configuration", "innodb", "2", "1", 0, 2, MySQLVersions{V8_0_46, Version{10, 2, 0}}},
+		"innodb_log_file_size":           {"innodb_log_file_size", "configuration", "innodb", "119537664", "50331648", 4194304, 0, MySQLVersions{Version{8, 0, 27}, V8_0_46}},
+		"innodb_log_files_in_group":      {"innodb_log_files_in_group", "configuration", "innodb", "2", "2", 2, 100, MySQLVersions{Version{8, 0, 27}, V8_0_46}},
+		"innodb_redo_log_capacity":       {"innodb_redo_log_capacity", "configuration", "innodb", "119537664", "104857600", 8388608, 137438953472, MySQLVersions{Version{8, 0, 31}, V11_1_1}},
+		//"innodb_page_cleaners":           {"innodb_page_cleaners", "configuration", "innodb", "1", "4", 1, 64, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_purge_threads":          {"innodb_purge_threads", "configuration", "innodb", "1", "4", 1, 32, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_io_capacity_max":        {"innodb_io_capacity_max", "configuration", "innodb", "20000", "20000", 100, 0, MySQLVersions{V8_0_46, Version{8, 8, 0}}},
+		"innodb_numa_interleave":        {"innodb_numa_interleave", "configuration", "innodb", "0", "1", 0, 0, MySQLVersions{V8_0_46, Version{8, 8, 0}}},
+		"innodb_buffer_pool_chunk_size": {"innodb_buffer_pool_chunk_size", "configuration", "innodb", "2097152", "134217728", 1048576, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_parallel_read_threads":  {"innodb_parallel_read_threads", "configuration", "innodb", "1", "4", 1, 256, MySQLVersions{V8_0_46, V11_1_1}},
+		"innodb_monitor_enable":         {"innodb_monitor_enable", "configuration", "innodb", "ALL", "ALL", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
 	}
 	wsrepGroup := map[string]Parameter{
-		"wsrep_sync_wait":         {"wsrep_sync_wait", "configuration", "galera", "0", "0", 0, 8, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"wsrep_slave_threads":     {"wsrep_slave_threads", "configuration", "galera", "2", "1", 1, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"wsrep_trx_fragment_size": {"wsrep_trx_fragment_size", "configuration", "galera", "1048576", "0", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"wsrep_trx_fragment_unit": {"wsrep_trx_fragment_unit", "configuration", "galera", "bytes", "bytes", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"wsrep-provider-options":  {"wsrep-provider-options", "configuration", "galera", "<placeholder>", "", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
+		"wsrep_sync_wait":         {"wsrep_sync_wait", "configuration", "galera", "0", "0", 0, 8, MySQLVersions{V8_0_46, V11_1_1}},
+		"wsrep_slave_threads":     {"wsrep_slave_threads", "configuration", "galera", "2", "1", 1, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"wsrep_trx_fragment_size": {"wsrep_trx_fragment_size", "configuration", "galera", "1048576", "0", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"wsrep_trx_fragment_unit": {"wsrep_trx_fragment_unit", "configuration", "galera", "bytes", "bytes", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		"wsrep-provider-options":  {"wsrep-provider-options", "configuration", "galera", "<placeholder>", "", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
 	}
 	groupReplicationGroup := map[string]Parameter{
-		"loose_group_replication_autorejoin_tries":               {"loose_group_replication_autorejoin_tries", "configuration", "groupReplication", "2", "3", 0, 8, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"loose_group_replication_flow_control_period":            {"loose_group_replication_flow_control_period", "configuration", "groupReplication", "1", "1", 1, 5, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"loose_group_replication_message_cache_size":             {"loose_group_replication_message_cache_size", "configuration", "groupReplication", "1073741824", "1073741824", 134217728, 18446744073709551615, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"loose_group_replication_communication_max_message_size": {"loose_group_replication_communication_max_message_size", "configuration", "groupReplication", "5097152", "10485760", 0, 1073741824, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"loose_group_replication_member_expel_timeout":           {"loose_group_replication_member_expel_timeout", "configuration", "groupReplication", "15", "5", 0, 3600, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"loose_group_replication_unreachable_majority_timeout":   {"loose_group_replication_unreachable_majority_timeout", "configuration", "groupReplication", "3600", "0", 300, 3600, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"loose_group_replication_poll_spin_loops": {"loose_group_replication_poll_spin_loops", "configuration", "groupReplication", "0", "0", 10000, 40000, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		//"loose_group_replication_compression_threshold":          {"loose_group_replication_compression_threshold", "configuration", "groupReplication", "1000000", "1000000", 129024, 1000000, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"loose_group_replication_paxos_single_leader":  {"loose_group_replication_paxos_single_leader", "configuration", "groupReplication", "ON", "OFF", 0, 1, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
-		"loose_binlog_transaction_dependency_tracking": {"loose_binlog_transaction_dependency_tracking", "configuration", "groupReplication", "WRITESET", "COMMIT_ORDER", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{8, 3, 0}}},
+		"loose_group_replication_autorejoin_tries":               {"loose_group_replication_autorejoin_tries", "configuration", "groupReplication", "2", "3", 0, 8, MySQLVersions{V8_0_46, V11_1_1}},
+		"loose_group_replication_flow_control_period":            {"loose_group_replication_flow_control_period", "configuration", "groupReplication", "1", "1", 1, 5, MySQLVersions{V8_0_46, V11_1_1}},
+		"loose_group_replication_message_cache_size":             {"loose_group_replication_message_cache_size", "configuration", "groupReplication", "1073741824", "1073741824", 134217728, 18446744073709551615, MySQLVersions{V8_0_46, V11_1_1}},
+		"loose_group_replication_communication_max_message_size": {"loose_group_replication_communication_max_message_size", "configuration", "groupReplication", "5097152", "10485760", 0, 1073741824, MySQLVersions{V8_0_46, V11_1_1}},
+		"loose_group_replication_member_expel_timeout":           {"loose_group_replication_member_expel_timeout", "configuration", "groupReplication", "15", "5", 0, 3600, MySQLVersions{V8_0_46, V11_1_1}},
+		//"loose_group_replication_unreachable_majority_timeout":   {"loose_group_replication_unreachable_majority_timeout", "configuration", "groupReplication", "3600", "0", 300, 3600, MySQLVersions{V8_0_46, V11_1_1}},
+		//"loose_group_replication_poll_spin_loops": {"loose_group_replication_poll_spin_loops", "configuration", "groupReplication", "0", "0", 10000, 40000, MySQLVersions{V8_0_46, V11_1_1}},
+		//"loose_group_replication_compression_threshold":          {"loose_group_replication_compression_threshold", "configuration", "groupReplication", "1000000", "1000000", 129024, 1000000, MySQLVersions{V8_0_46, V11_1_1}},
+		"loose_group_replication_paxos_single_leader":  {"loose_group_replication_paxos_single_leader", "configuration", "groupReplication", "ON", "OFF", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
+		"loose_binlog_transaction_dependency_tracking": {"loose_binlog_transaction_dependency_tracking", "configuration", "groupReplication", "WRITESET", "COMMIT_ORDER", 0, 0, MySQLVersions{V8_0_46, Version{8, 3, 0}}},
 		//"loose_group_replication_view_change_uuid":               {"loose_group_replication_view_change_uuid", "configuration", "groupReplication", "AUTOMATIC", "AUTOMATIC", 0, 0},
-		//"loose_group_replication_exit_state_action":              {"loose_group_replication_exit_state_action", "configuration", "groupReplication", "READ_ONLY", "READ_ONLY", 0, 0, MySQLVersions{Version{8, 0, 30}, Version{10, 1, 0}}},
+		//"loose_group_replication_exit_state_action":              {"loose_group_replication_exit_state_action", "configuration", "groupReplication", "READ_ONLY", "READ_ONLY", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
 
 	}
 
@@ -582,8 +497,8 @@ func InBetweenFloat(val, min, max float64) bool {
 }
 
 func (conf *Configuration) getMySQLVersion() {
-	conf.Mysqlversions.Max = Version{10, 10, 0}
-	conf.Mysqlversions.Min = Version{8, 0, 32}
+	conf.Mysqlversions.Max = MySQLMaxSupported
+	conf.Mysqlversions.Min = MySQLMinSupported
 }
 
 // =====================================================

--- a/src/mysqloperatorcalculator/Constants.go
+++ b/src/mysqloperatorcalculator/Constants.go
@@ -97,4 +97,5 @@ const (
 	- read/write 50/50
 	*/
 	// Global
+
 )

--- a/src/mysqloperatorcalculator/Constants.go
+++ b/src/mysqloperatorcalculator/Constants.go
@@ -1,0 +1,99 @@
+package mysqloperatorcalculator
+
+// ***********************************
+// Constants
+// ***********************************
+const (
+	VERSION = "v1.11.0"
+
+	OkI                    = 1001
+	ClosetolimitI          = 2001
+	OverutilizingI         = 3001
+	ErrorexecI             = 5001
+	ConnectionRecalculated = 6001
+	ResourcesRecalculated  = 7001
+
+	OkT                       = "Execution was successful and resources match the possible requests"
+	ClosetolimitT             = "Execution was successful however resources are close to saturation based on the load requested"
+	OverutilizingT            = "Resources not enough to cover the requested load "
+	ErrorexecT                = "There is an error while processing. See details: %s"
+	ConnectionRecalculatedTxt = "The number of connection has been recalculated to match the available resources"
+	ResourcesRecalculatedTxt  = "Minimum resource estimates have been updated to correspond with the specified connection count."
+
+	LoadTypeMostlyReads      = 1
+	LoadTypeSomeWrites       = 2
+	LoadTypeEqualReadsWrites = 3
+	LoadTypeHeavyWrites      = 4
+
+	DimensionOpen       = 999
+	ConnectionDimension = 998
+
+	FamilyTypeMysql   = "mysql"
+	FamilyTypeProxy   = "proxy"
+	FamilyTypeMonitor = "monitor"
+
+	GroupNameMySQLd    = "mysqld"
+	GroupNameProbes    = "probes"
+	GroupNameResources = "resources"
+	GroupNameHAProxy   = "haproxyConfig"
+
+	DbTypePXC              = "pxc"
+	DbTypeGroupReplication = "group_replication"
+
+	ResultOutputFormatJson  = "json"
+	ResultOutputFormatHuman = "human"
+
+	InnoDBPctValuePXC = 0.80
+	InnoDBPctValueGR  = 0.70
+
+	GroupRepGCSCacheMemStructureCost = 52428800
+
+	MinLimitPXC            = 0.50
+	MinLimitGR             = 0.40
+	MemoryFreeMinimumLimit = 0.02
+
+	/* Minlimit is the % of memory assigned to Innodb buffer pool compared to the total memory assigned to mysql
+	We have different min limit per type of replication (galera and Group replication) because the different impact of the internal cache.
+	In GR the certification cache is suffering of an issue. In short the certification cache is clean/flushed on commit, but if the operation is a long one like insert into A from select * from b ;
+	and we have large dataset, this may cause the cache buffer to be very large and causing issues like swap or OOM kill.
+	While we cannot prevent this to happen, we need to consider the possible impact of it.
+	Also other caches used by GR and more frequently cleanup are causing higher memory consumption than galera.
+	as such we need to allocate less memory to innodb and more to buffers.
+	By consequence the % of innodb memory for galera is higher than GR
+	*/
+	// MemoryFreeMinimumLimit This is the amount of memory in % that we must keep free no matter what to give some space to the server
+
+	// Weight to use when using PXC for Gcache in mem footprint
+	GcacheFootPrintFactorRead       = 0.5
+	GcacheFootPrintFactorLightWrite = 0.6
+	GcacheFootPrintFactorReadWrite  = 0.8
+
+	// Weights to use to tune the GCS calculation against connections
+	GCSConnWeight = 10 //each connection costs 10 millicycles
+	// TODO Deprecated
+	//GCSWeightRead           = 0.40
+	//GCSWeightReadLightWrite = 0.60
+	//GCSWeightReadWrite      = 1.20
+	//GCSWeightReadHeavyWrite = 1
+
+	CPUIncrement    = 200
+	MemoryIncrement = 500
+
+	CpuConncetionMillFactorRead           = 0.8
+	CpuConncetionMillFactorReadWriteLight = 1.2
+	CpuConncetionMillFactorReadWriteEqual = 1.6
+	CpuConncetionMillFactorReadWriteHeavy = 2
+
+	ConnectionWeighPctLimit = 0.50
+	MinConnectionNumber     = 20
+
+	/*Connection / CPU adjustment factor this is the factor by which we divide the available CPU mill reporting th emaximum number of connections available
+	if we assign 2000 CPU and ask for 100 connection the formula will be CPUmill/CpuConncetionMillFactor < Connection asked
+	if the number of CPUmill/CpuConncetionMillFactor > Connection asked we are overloading the platform
+	We hace 3 different load factors:
+	- mainly read
+	- read/write 80/20
+	- read/write 50/50
+	*/
+	// Global
+)

--- a/src/mysqloperatorcalculator/Constants.go
+++ b/src/mysqloperatorcalculator/Constants.go
@@ -86,6 +86,7 @@ const (
 
 	ConnectionWeighPctLimit = 0.50
 	MinConnectionNumber     = 20
+	MaxAutoConnections      = 500000
 
 	/*Connection / CPU adjustment factor this is the factor by which we divide the available CPU mill reporting th emaximum number of connections available
 	if we assign 2000 CPU and ask for 100 connection the formula will be CPUmill/CpuConncetionMillFactor < Connection asked

--- a/src/mysqloperatorcalculator/Constants.go
+++ b/src/mysqloperatorcalculator/Constants.go
@@ -4,7 +4,7 @@ package mysqloperatorcalculator
 // Constants
 // ***********************************
 const (
-	VERSION = "v1.11.0"
+	VERSION = "v1.20.0"
 
 	OkI                    = 1001
 	ClosetolimitI          = 2001

--- a/src/mysqloperatorcalculator/configuration_test.go
+++ b/src/mysqloperatorcalculator/configuration_test.go
@@ -1,0 +1,143 @@
+package mysqloperatorcalculator
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Configuration.GetDimensionByID
+// ---------------------------------------------------------------------------
+
+func TestGetDimensionByID_Valid(t *testing.T) {
+	var conf Configuration
+	conf.Init()
+
+	cases := []struct {
+		id      int
+		wantCPU int
+	}{
+		{1, 1000},  // XSmall
+		{2, 2500},  // Small
+		{3, 4500},  // Medium
+		{10, 96000}, // 24XLarge
+	}
+	for _, tc := range cases {
+		dim := conf.GetDimensionByID(tc.id)
+		if dim.Id != tc.id {
+			t.Errorf("GetDimensionByID(%d).Id = %d, want %d", tc.id, dim.Id, tc.id)
+		}
+		if dim.Cpu != tc.wantCPU {
+			t.Errorf("GetDimensionByID(%d).Cpu = %d, want %d", tc.id, dim.Cpu, tc.wantCPU)
+		}
+		if dim.MysqlCpu == 0 {
+			t.Errorf("GetDimensionByID(%d).MysqlCpu not set", tc.id)
+		}
+		if dim.MysqlMemory == 0 {
+			t.Errorf("GetDimensionByID(%d).MysqlMemory not set", tc.id)
+		}
+	}
+}
+
+func TestGetDimensionByID_Invalid(t *testing.T) {
+	var conf Configuration
+	conf.Init()
+	dim := conf.GetDimensionByID(99999)
+	if dim.Id != 0 {
+		t.Errorf("expected zero Dimension for unknown ID, got Id=%d", dim.Id)
+	}
+}
+
+func TestGetDimensionByID_ResourceSplit(t *testing.T) {
+	var conf Configuration
+	conf.Init()
+	// Each component must be positive and the sum must not exceed the total CPU.
+	// Some dimensions intentionally reserve a portion of CPU as node overhead.
+	for _, dim := range conf.Dimension {
+		if dim.Id == DimensionOpen || dim.Id == ConnectionDimension {
+			continue
+		}
+		total := dim.MysqlCpu + dim.ProxyCpu + dim.PmmCpu
+		if total > dim.Cpu {
+			t.Errorf("dim %d (%s): CPU split %d+%d+%d=%d exceeds total %d",
+				dim.Id, dim.Name, dim.MysqlCpu, dim.ProxyCpu, dim.PmmCpu, total, dim.Cpu)
+		}
+		if dim.MysqlCpu <= 0 || dim.ProxyCpu <= 0 || dim.PmmCpu <= 0 {
+			t.Errorf("dim %d (%s): all CPU components must be > 0, got MySQL=%d Proxy=%d PMM=%d",
+				dim.Id, dim.Name, dim.MysqlCpu, dim.ProxyCpu, dim.PmmCpu)
+		}
+	}
+}
+
+func TestGetDimensionByID_MemoryBytes(t *testing.T) {
+	var conf Configuration
+	conf.Init()
+	for _, dim := range conf.Dimension {
+		if dim.Id == DimensionOpen || dim.Id == ConnectionDimension {
+			continue
+		}
+		if dim.MemoryBytes == 0 {
+			t.Errorf("dim %d (%s): MemoryBytes is 0", dim.Id, dim.Name)
+		}
+		if dim.MysqlMemory == 0 {
+			t.Errorf("dim %d (%s): MysqlMemory is 0", dim.Id, dim.Name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Configuration.GetLoadByID
+// ---------------------------------------------------------------------------
+
+func TestGetLoadByID_Valid(t *testing.T) {
+	var conf Configuration
+	conf.Init()
+	for _, id := range []int{LoadTypeMostlyReads, LoadTypeSomeWrites, LoadTypeEqualReadsWrites} {
+		load := conf.GetLoadByID(id)
+		if load.Id != id {
+			t.Errorf("GetLoadByID(%d) returned Id=%d", id, load.Id)
+		}
+		if load.Name == "" {
+			t.Errorf("GetLoadByID(%d) has empty Name", id)
+		}
+	}
+}
+
+func TestGetLoadByID_Invalid(t *testing.T) {
+	var conf Configuration
+	conf.Init()
+	load := conf.GetLoadByID(9999)
+	if load.Id != 0 {
+		t.Errorf("expected zero LoadType for unknown ID, got Id=%d", load.Id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dimension.ConvertMemoryToBytes
+// ---------------------------------------------------------------------------
+
+func TestConvertMemoryToBytes(t *testing.T) {
+	cases := []struct {
+		input string
+		want  float64
+	}{
+		{"2GB", 2 * 1024 * 1024 * 1024},
+		{"4GB", 4 * 1024 * 1024 * 1024},
+		{"512MB", 512 * 1024 * 1024},
+	}
+	for _, tc := range cases {
+		var d Dimension
+		got, err := d.ConvertMemoryToBytes(tc.input)
+		if err != nil {
+			t.Errorf("ConvertMemoryToBytes(%q) unexpected error: %v", tc.input, err)
+		}
+		if got != tc.want {
+			t.Errorf("ConvertMemoryToBytes(%q) = %f, want %f", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestConvertMemoryToBytes_Invalid(t *testing.T) {
+	var d Dimension
+	_, err := d.ConvertMemoryToBytes("not-a-size")
+	if err == nil {
+		t.Error("expected error for invalid memory string, got nil")
+	}
+}

--- a/src/mysqloperatorcalculator/configurator.go
+++ b/src/mysqloperatorcalculator/configurator.go
@@ -208,21 +208,50 @@ func (c *Configurator) filterByMySQLVersion() map[string]Family {
 	return c.families
 }
 
+// loadValues returns one of four values indexed by current load type [MostlyReads, SomeWrites, EqualReadsWrites, HeavyWrites].
+func (c *Configurator) loadValues(byLoad [4]string) string {
+	switch c.reference.loadID {
+	case LoadTypeMostlyReads:
+		return byLoad[0]
+	case LoadTypeSomeWrites:
+		return byLoad[1]
+	case LoadTypeEqualReadsWrites:
+		return byLoad[2]
+	case LoadTypeHeavyWrites:
+		return byLoad[3]
+	default:
+		return byLoad[1]
+	}
+}
+
+// loadFloat returns one of four floats indexed by current load type [MostlyReads, SomeWrites, EqualReadsWrites, HeavyWrites].
+func (c *Configurator) loadFloat(byLoad [4]float64) float64 {
+	switch c.reference.loadID {
+	case LoadTypeMostlyReads:
+		return byLoad[0]
+	case LoadTypeSomeWrites:
+		return byLoad[1]
+	case LoadTypeEqualReadsWrites:
+		return byLoad[2]
+	case LoadTypeHeavyWrites:
+		return byLoad[3]
+	default:
+		return byLoad[0]
+	}
+}
+
 func (c *Configurator) getGcache() {
 	c.reference.gcache = int64(float64(c.reference.innodbRedoLogDim) * c.reference.gcacheLoad)
 	if c.reference.gcache > (c.reference.memoryLeftover / 3) {
 		c.reference.gcache = c.reference.memoryLeftover / 3
 	}
 
-	gcacheFootPrintFactor := 0.5
-	switch c.reference.loadID {
-	case 1:
-		gcacheFootPrintFactor = GcacheFootPrintFactorRead
-	case 2:
-		gcacheFootPrintFactor = GcacheFootPrintFactorLightWrite
-	case 3:
-		gcacheFootPrintFactor = GcacheFootPrintFactorReadWrite
-	}
+	gcacheFootPrintFactor := c.loadFloat([4]float64{
+		GcacheFootPrintFactorRead,
+		GcacheFootPrintFactorLightWrite,
+		GcacheFootPrintFactorReadWrite,
+		0.5,
+	})
 
 	c.reference.gcacheFootprint = int64(math.Ceil(float64(c.reference.gcache) * gcacheFootPrintFactor))
 	c.reference.memoryLeftover -= c.reference.gcacheFootprint
@@ -254,54 +283,22 @@ func (c *Configurator) getConnectionBuffers() {
 }
 
 func (c *Configurator) paramBinlogCacheSize(inParameter Parameter) Parameter {
-	switch c.reference.loadID {
-	case LoadTypeMostlyReads:
-		inParameter.Value = "32768"
-	case LoadTypeSomeWrites:
-		inParameter.Value = "131072"
-	case LoadTypeEqualReadsWrites:
-		inParameter.Value = "262144"
-	case LoadTypeHeavyWrites:
-		inParameter.Value = "358400"
-	}
+	inParameter.Value = c.loadValues([4]string{"32768", "131072", "262144", "358400"})
 	return inParameter
 }
 
 func (c *Configurator) paramJoinBuffer(inParameter Parameter) Parameter {
-	switch c.reference.loadID {
-	case LoadTypeMostlyReads:
-		inParameter.Value = "262144"
-	case LoadTypeSomeWrites:
-		inParameter.Value = "524288"
-	case LoadTypeEqualReadsWrites, LoadTypeHeavyWrites: // Combined identical cases
-		inParameter.Value = "1048576"
-	}
+	inParameter.Value = c.loadValues([4]string{"262144", "524288", "1048576", "1048576"})
 	return inParameter
 }
 
 func (c *Configurator) paramReadRndBuffer(inParameter Parameter) Parameter {
-	switch c.reference.loadID {
-	case LoadTypeMostlyReads:
-		inParameter.Value = "262144"
-	case LoadTypeSomeWrites:
-		inParameter.Value = "393216"
-	case LoadTypeEqualReadsWrites, LoadTypeHeavyWrites:
-		inParameter.Value = "707788"
-	}
+	inParameter.Value = c.loadValues([4]string{"262144", "393216", "707788", "707788"})
 	return inParameter
 }
 
 func (c *Configurator) paramSortBuffer(inParameter Parameter) Parameter {
-	switch c.reference.loadID {
-	case LoadTypeMostlyReads:
-		inParameter.Value = "262144"
-	case LoadTypeSomeWrites:
-		inParameter.Value = "524288"
-	case LoadTypeEqualReadsWrites:
-		inParameter.Value = "1572864"
-	case LoadTypeHeavyWrites:
-		inParameter.Value = "2097152"
-	}
+	inParameter.Value = c.loadValues([4]string{"262144", "524288", "1572864", "2097152"})
 	return inParameter
 }
 
@@ -309,15 +306,7 @@ func (c *Configurator) paramSortBuffer(inParameter Parameter) Parameter {
 func (c *Configurator) calculateTmpTableFootprint(inParameter Parameter) {
 	c.reference.tmpTableFootprint, _ = strconv.ParseInt(inParameter.Value, 10, 64)
 
-	multiplier := 0.2
-	switch c.reference.loadID {
-	case LoadTypeSomeWrites:
-		multiplier = 0.1
-	case LoadTypeEqualReadsWrites:
-		multiplier = 0.3
-	case LoadTypeHeavyWrites:
-		multiplier = 0.05
-	}
+	multiplier := c.loadFloat([4]float64{0.2, 0.1, 0.3, 0.05})
 
 	c.reference.tmpTableFootprint = int64(float64(c.reference.tmpTableFootprint) * multiplier)
 }
@@ -400,14 +389,7 @@ func (c *Configurator) getRedologfilesNumber(dimension int64, parameter Paramete
 }
 
 func (c *Configurator) getGcacheLoad() float64 {
-	switch c.reference.loadID {
-	case LoadTypeSomeWrites:
-		return 1.15
-	case LoadTypeEqualReadsWrites:
-		return 1.2
-	default:
-		return 1
-	}
+	return c.loadFloat([4]float64{1.0, 1.15, 1.2, 1.0})
 }
 
 func (c *Configurator) getInnodbBufferPool(final bool) {
@@ -459,7 +441,7 @@ func (c *Configurator) paramInnoDBBufferPool(parameter Parameter, final bool) Pa
 
 	if !final {
 		bufferPool := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
-		bufferPoolSubstract := int64(math.Floor(float64(c.reference.memoryLeftover) * InnoDBPctValuePXC))
+		bufferPoolSubstract := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
 
 		parameter.Value = strconv.FormatInt(bufferPool, 10)
 		c.reference.innoDBbpSize = bufferPool
@@ -478,6 +460,16 @@ func (c *Configurator) paramInnoDBBufferPool(parameter Parameter, final bool) Pa
 			// the memory left over at this point is expected to be negative
 			bufferPool = c.reference.innoDBbpSize - int64(math.Abs(float64(c.reference.memoryLeftover)))
 			c.reference.memoryLeftover = 0
+
+			// Enforce minimum buffer pool floor to prevent going dangerously low
+			minPct := MinLimitGR
+			if c.request.DBType == "pxc" {
+				minPct = MinLimitPXC
+			}
+			minBufferPool := int64(c.reference.memoryMySQL * minPct)
+			if bufferPool < minBufferPool {
+				bufferPool = minBufferPool
+			}
 		}
 
 		parameter.Value = strconv.FormatInt(bufferPool, 10)
@@ -571,22 +563,14 @@ func (c *Configurator) paramInnoDPurgeThreads(parameter Parameter) Parameter {
 }
 
 func (c *Configurator) paramInnoDBIOCapacityMax(parameter Parameter) Parameter {
-	switch c.reference.loadID {
-	case LoadTypeMostlyReads:
-		parameter.Value = "28000"
-	case LoadTypeSomeWrites:
-		parameter.Value = "24000"
-	case LoadTypeEqualReadsWrites:
-		parameter.Value = "20000"
-	default:
-		parameter.Value = "20000"
-	}
+	parameter.Value = c.loadValues([4]string{"28000", "24000", "20000", "20000"})
 	return parameter
 }
 
 func (c *Configurator) getServerParameters() {
 	group := c.families["mysql"].Groups["configuration_server"]
 	group.Parameters["max_connections"] = c.paramServerMaxConnections(group.Parameters["max_connections"])
+	// TODO re-enable once we have better TP handling in PS
 	//group.Parameters["thread_pool_size"] = c.paramServerThreadPool(group.Parameters["thread_pool_size"])
 	//group.Parameters["table_definition_cache"] = c.paramServerTableDefinitionCache(group.Parameters["table_definition_cache"])
 	//group.Parameters["table_open_cache"] = c.paramServerTableOpenCache(group.Parameters["table_open_cache"])

--- a/src/mysqloperatorcalculator/configurator_test.go
+++ b/src/mysqloperatorcalculator/configurator_test.go
@@ -1,0 +1,419 @@
+package mysqloperatorcalculator
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+const (
+	testMB = 1024 * 1024
+	testGB = 1024 * testMB
+)
+
+// newTestConfigurator builds a Configurator with controlled state for unit testing.
+// It does not call Init() so families/providerParams are intentionally empty.
+func newTestConfigurator(loadID int, dbtype string, connections int, mysqlCPU float64, mysqlMemBytes float64) *Configurator {
+	return &Configurator{
+		request: ConfigurationRequest{
+			DBType:      dbtype,
+			Connections: connections,
+			LoadType:    LoadType{Id: loadID},
+		},
+		reference: &references{
+			loadID:      loadID,
+			connections: connections,
+			cpusMySQL:   mysqlCPU,
+			memoryMySQL: mysqlMemBytes,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CalculateReturnBytes
+// ---------------------------------------------------------------------------
+
+func TestCalculateReturnBytes_BelowMinThreshold(t *testing.T) {
+	c := &Configurator{reference: &references{}}
+	input := int64(100 * testMB)
+	got := c.CalculateReturnBytes(input)
+	want := int64(float64(input) * 0.20)
+	if got != want {
+		t.Errorf("CalculateReturnBytes(100MB) = %d, want %d", got, want)
+	}
+}
+
+func TestCalculateReturnBytes_AboveMaxThreshold(t *testing.T) {
+	c := &Configurator{reference: &references{}}
+	input := int64(2048 * testMB)
+	got := c.CalculateReturnBytes(input)
+	want := int64(float64(input) * 0.85)
+	if got != want {
+		t.Errorf("CalculateReturnBytes(2048MB) = %d, want %d", got, want)
+	}
+}
+
+func TestCalculateReturnBytes_Interpolated(t *testing.T) {
+	c := &Configurator{reference: &references{}}
+	input := int64(1024 * testMB) // 1GB: midpoint between 300MB and 2GB thresholds
+	got := c.CalculateReturnBytes(input)
+	// Should be between 20% and 85%
+	low := int64(float64(input) * 0.20)
+	high := int64(float64(input) * 0.85)
+	if got < low || got > high {
+		t.Errorf("CalculateReturnBytes(1GB) = %d, want value in [%d, %d]", got, low, high)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loadValues / loadFloat helpers
+// ---------------------------------------------------------------------------
+
+func TestLoadValues_AllLoadTypes(t *testing.T) {
+	cases := []struct {
+		loadID int
+		want   string
+	}{
+		{LoadTypeMostlyReads, "A"},
+		{LoadTypeSomeWrites, "B"},
+		{LoadTypeEqualReadsWrites, "C"},
+		{LoadTypeHeavyWrites, "D"},
+		{99, "B"}, // unknown ID falls back to index 1 (SomeWrites)
+	}
+	for _, tc := range cases {
+		c := newTestConfigurator(tc.loadID, DbTypePXC, 50, 1200, 4*testGB)
+		got := c.loadValues([4]string{"A", "B", "C", "D"})
+		if got != tc.want {
+			t.Errorf("loadID=%d: loadValues() = %q, want %q", tc.loadID, got, tc.want)
+		}
+	}
+}
+
+func TestLoadFloat_AllLoadTypes(t *testing.T) {
+	cases := []struct {
+		loadID int
+		want   float64
+	}{
+		{LoadTypeMostlyReads, 1.0},
+		{LoadTypeSomeWrites, 2.0},
+		{LoadTypeEqualReadsWrites, 3.0},
+		{LoadTypeHeavyWrites, 4.0},
+		{99, 1.0}, // unknown ID falls back to index 0 (MostlyReads)
+	}
+	for _, tc := range cases {
+		c := newTestConfigurator(tc.loadID, DbTypePXC, 50, 1200, 4*testGB)
+		got := c.loadFloat([4]float64{1.0, 2.0, 3.0, 4.0})
+		if got != tc.want {
+			t.Errorf("loadID=%d: loadFloat() = %f, want %f", tc.loadID, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getGcacheLoad
+// ---------------------------------------------------------------------------
+
+func TestGetGcacheLoad(t *testing.T) {
+	cases := []struct {
+		loadID int
+		want   float64
+	}{
+		{LoadTypeMostlyReads, 1.0},
+		{LoadTypeSomeWrites, 1.15},
+		{LoadTypeEqualReadsWrites, 1.2},
+		{LoadTypeHeavyWrites, 1.0},
+	}
+	for _, tc := range cases {
+		c := newTestConfigurator(tc.loadID, DbTypePXC, 50, 1200, 4*testGB)
+		got := c.getGcacheLoad()
+		if got != tc.want {
+			t.Errorf("loadID=%d: getGcacheLoad() = %f, want %f", tc.loadID, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// calculateTmpTableFootprint
+// ---------------------------------------------------------------------------
+
+func TestCalculateTmpTableFootprint(t *testing.T) {
+	base := int64(testMB) // 1 MB tmp_table_size
+	cases := []struct {
+		loadID   int
+		wantMult float64
+	}{
+		{LoadTypeMostlyReads, 0.2},
+		{LoadTypeSomeWrites, 0.1},
+		{LoadTypeEqualReadsWrites, 0.3},
+		{LoadTypeHeavyWrites, 0.05},
+	}
+	for _, tc := range cases {
+		c := newTestConfigurator(tc.loadID, DbTypePXC, 50, 1200, 4*testGB)
+		p := Parameter{Value: strconv.FormatInt(base, 10)}
+		c.calculateTmpTableFootprint(p)
+		want := int64(float64(base) * tc.wantMult)
+		if c.reference.tmpTableFootprint != want {
+			t.Errorf("loadID=%d: tmpTableFootprint = %d, want %d", tc.loadID, c.reference.tmpTableFootprint, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Connection buffer parameter values
+// ---------------------------------------------------------------------------
+
+func TestParamConnectionBuffers(t *testing.T) {
+	cases := []struct {
+		loadID      int
+		wantJoin    string
+		wantSort    string
+		wantReadRnd string
+		wantBinlog  string
+	}{
+		{LoadTypeMostlyReads, "262144", "262144", "262144", "32768"},
+		{LoadTypeSomeWrites, "524288", "524288", "393216", "131072"},
+		{LoadTypeEqualReadsWrites, "1048576", "1572864", "707788", "262144"},
+		{LoadTypeHeavyWrites, "1048576", "2097152", "707788", "358400"},
+	}
+	for _, tc := range cases {
+		c := newTestConfigurator(tc.loadID, DbTypePXC, 50, 1200, 4*testGB)
+		p := Parameter{}
+
+		if got := c.paramJoinBuffer(p).Value; got != tc.wantJoin {
+			t.Errorf("loadID=%d paramJoinBuffer: got %s, want %s", tc.loadID, got, tc.wantJoin)
+		}
+		if got := c.paramSortBuffer(p).Value; got != tc.wantSort {
+			t.Errorf("loadID=%d paramSortBuffer: got %s, want %s", tc.loadID, got, tc.wantSort)
+		}
+		if got := c.paramReadRndBuffer(p).Value; got != tc.wantReadRnd {
+			t.Errorf("loadID=%d paramReadRndBuffer: got %s, want %s", tc.loadID, got, tc.wantReadRnd)
+		}
+		if got := c.paramBinlogCacheSize(p).Value; got != tc.wantBinlog {
+			t.Errorf("loadID=%d paramBinlogCacheSize: got %s, want %s", tc.loadID, got, tc.wantBinlog)
+		}
+	}
+}
+
+func TestParamInnoDBIOCapacityMax(t *testing.T) {
+	cases := []struct {
+		loadID int
+		want   string
+	}{
+		{LoadTypeMostlyReads, "28000"},
+		{LoadTypeSomeWrites, "24000"},
+		{LoadTypeEqualReadsWrites, "20000"},
+		{LoadTypeHeavyWrites, "20000"},
+	}
+	for _, tc := range cases {
+		c := newTestConfigurator(tc.loadID, DbTypePXC, 50, 1200, 4*testGB)
+		got := c.paramInnoDBIOCapacityMax(Parameter{}).Value
+		if got != tc.want {
+			t.Errorf("loadID=%d paramInnoDBIOCapacityMax: got %s, want %s", tc.loadID, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// calculateLoadConnectionFactor
+// ---------------------------------------------------------------------------
+
+func TestCalculateLoadConnectionFactor(t *testing.T) {
+	cases := []struct {
+		name        string
+		loadID      int
+		mysqlCPU    int
+		connections int
+		wantOver    bool
+	}{
+		{"reads well within capacity", LoadTypeMostlyReads, 4000, 50, false},
+		{"reads at comfortable limit", LoadTypeMostlyReads, 4000, 3000, false},
+		{"heavy writes over limit", LoadTypeHeavyWrites, 1000, 5000, true},
+		{"light writes over limit", LoadTypeSomeWrites, 600, 1000, true},
+		{"equal reads-writes within limit", LoadTypeEqualReadsWrites, 8000, 200, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dim := Dimension{MysqlCpu: tc.mysqlCPU}
+			c := &Configurator{
+				reference: &references{
+					loadID:      tc.loadID,
+					connections: tc.connections,
+				},
+			}
+			_, _, over := c.calculateLoadConnectionFactor(dim, ResponseMessage{})
+			if over != tc.wantOver {
+				t.Errorf("over=%v, want %v", over, tc.wantOver)
+			}
+		})
+	}
+}
+
+func TestCalculateLoadConnectionFactor_ReturnsPositiveFactor(t *testing.T) {
+	dim := Dimension{MysqlCpu: 4000}
+	c := &Configurator{
+		reference: &references{
+			loadID:      LoadTypeMostlyReads,
+			connections: 100,
+		},
+	}
+	factor, _, over := c.calculateLoadConnectionFactor(dim, ResponseMessage{})
+	if over {
+		t.Fatal("expected not over, got over")
+	}
+	if factor <= 0 || factor > 1 {
+		t.Errorf("loadFactor = %f, want value in (0, 1]", factor)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// paramInnoDBBufferPool — first pass
+// ---------------------------------------------------------------------------
+
+func TestParamInnoDBBufferPool_FirstPass_PXC(t *testing.T) {
+	memLeftover := int64(8 * testGB)
+	c := &Configurator{
+		request:   ConfigurationRequest{DBType: DbTypePXC},
+		reference: &references{memoryLeftover: memLeftover},
+	}
+	result := c.paramInnoDBBufferPool(Parameter{}, false)
+	want := int64(float64(memLeftover) * InnoDBPctValuePXC)
+	got, _ := strconv.ParseInt(result.Value, 10, 64)
+	if got != want {
+		t.Errorf("PXC first pass bufferPool = %d, want %d", got, want)
+	}
+	if c.reference.innoDBbpSize != want {
+		t.Errorf("PXC first pass innoDBbpSize = %d, want %d", c.reference.innoDBbpSize, want)
+	}
+	// leftover should be reduced by the allocated amount
+	if c.reference.memoryLeftover != memLeftover-want {
+		t.Errorf("PXC first pass memoryLeftover = %d, want %d", c.reference.memoryLeftover, memLeftover-want)
+	}
+}
+
+func TestParamInnoDBBufferPool_FirstPass_GR(t *testing.T) {
+	memLeftover := int64(8 * testGB)
+	c := &Configurator{
+		request:   ConfigurationRequest{DBType: DbTypeGroupReplication},
+		reference: &references{memoryLeftover: memLeftover},
+	}
+	result := c.paramInnoDBBufferPool(Parameter{}, false)
+	want := int64(float64(memLeftover) * InnoDBPctValueGR)
+	got, _ := strconv.ParseInt(result.Value, 10, 64)
+	if got != want {
+		t.Errorf("GR first pass bufferPool = %d, want %d", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// paramInnoDBBufferPool — second pass, positive leftover
+// ---------------------------------------------------------------------------
+
+func TestParamInnoDBBufferPool_SecondPass_PositiveLeftover(t *testing.T) {
+	bpSize := int64(5 * testGB)
+	leftover := int64(500 * testMB)
+	c := &Configurator{
+		request: ConfigurationRequest{DBType: DbTypePXC},
+		reference: &references{
+			memoryMySQL:    float64(8 * testGB),
+			innoDBbpSize:   bpSize,
+			memoryLeftover: leftover,
+		},
+	}
+	result := c.paramInnoDBBufferPool(Parameter{}, true)
+	got, _ := strconv.ParseInt(result.Value, 10, 64)
+	// Buffer pool must be larger than the initial size (leftover was reassigned)
+	if got <= bpSize {
+		t.Errorf("second pass positive leftover: bufferPool %d should be > initial %d", got, bpSize)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// paramInnoDBBufferPool — second pass, negative leftover with floor guard
+// ---------------------------------------------------------------------------
+
+func TestParamInnoDBBufferPool_SecondPass_NegativeLeftover_FloorEnforced_PXC(t *testing.T) {
+	totalMySQLMem := float64(8 * testGB)
+	// Set a buffer pool so small that subtracting the overrun would go below MinLimitPXC
+	c := &Configurator{
+		request: ConfigurationRequest{DBType: DbTypePXC},
+		reference: &references{
+			memoryMySQL:    totalMySQLMem,
+			innoDBbpSize:   int64(2 * testGB),   // very small initial BP
+			memoryLeftover: int64(-3 * testGB),  // large overrun
+		},
+	}
+	result := c.paramInnoDBBufferPool(Parameter{}, true)
+	got, _ := strconv.ParseInt(result.Value, 10, 64)
+	minAllowed := int64(totalMySQLMem * MinLimitPXC)
+	if got < minAllowed {
+		t.Errorf("PXC bufferPool %d is below minimum floor %d", got, minAllowed)
+	}
+}
+
+func TestParamInnoDBBufferPool_SecondPass_NegativeLeftover_FloorEnforced_GR(t *testing.T) {
+	totalMySQLMem := float64(8 * testGB)
+	c := &Configurator{
+		request: ConfigurationRequest{DBType: DbTypeGroupReplication},
+		reference: &references{
+			memoryMySQL:    totalMySQLMem,
+			innoDBbpSize:   int64(2 * testGB),
+			memoryLeftover: int64(-3 * testGB),
+		},
+	}
+	result := c.paramInnoDBBufferPool(Parameter{}, true)
+	got, _ := strconv.ParseInt(result.Value, 10, 64)
+	minAllowed := int64(totalMySQLMem * MinLimitGR)
+	if got < minAllowed {
+		t.Errorf("GR bufferPool %d is below minimum floor %d", got, minAllowed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FillResponseMessage — saturation classification thresholds
+// ---------------------------------------------------------------------------
+
+func TestFillResponseMessage(t *testing.T) {
+	cases := []struct {
+		name     string
+		bpPct    float64
+		dbtype   string
+		wantType int
+	}{
+		// PXC: MinLimitPXC=0.50, close-to-limit band [0.50, 0.60]
+		{"PXC below min", 0.35, DbTypePXC, OverutilizingI},
+		{"PXC at min", 0.50, DbTypePXC, ClosetolimitI},
+		{"PXC close to limit", 0.55, DbTypePXC, ClosetolimitI},
+		{"PXC ok", 0.70, DbTypePXC, OkI},
+
+		// GR: MinLimitGR=0.40, close-to-limit band [0.40, 0.50]
+		{"GR below min", 0.30, DbTypeGroupReplication, OverutilizingI},
+		{"GR at min", 0.40, DbTypeGroupReplication, ClosetolimitI},
+		{"GR close to limit", 0.45, DbTypeGroupReplication, ClosetolimitI},
+		{"GR ok", 0.60, DbTypeGroupReplication, OkI},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Configurator{reference: &references{}}
+			msg, _ := c.FillResponseMessage(tc.bpPct, ResponseMessage{}, bytes.Buffer{}, tc.dbtype)
+			if msg.MType != tc.wantType {
+				t.Errorf("bpPct=%.2f dbtype=%s: MType=%d, want %d", tc.bpPct, tc.dbtype, msg.MType, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestFillResponseMessage_OverutilizingReturnsTrue(t *testing.T) {
+	c := &Configurator{reference: &references{}}
+	_, over := c.FillResponseMessage(0.20, ResponseMessage{}, bytes.Buffer{}, DbTypePXC)
+	if !over {
+		t.Error("expected overUtilizing=true for bpPct=0.20 on PXC")
+	}
+}
+
+func TestFillResponseMessage_OkReturnsFalse(t *testing.T) {
+	c := &Configurator{reference: &references{}}
+	_, over := c.FillResponseMessage(0.75, ResponseMessage{}, bytes.Buffer{}, DbTypePXC)
+	if over {
+		t.Error("expected overUtilizing=false for bpPct=0.75 on PXC")
+	}
+}

--- a/src/mysqloperatorcalculator/integration_test.go
+++ b/src/mysqloperatorcalculator/integration_test.go
@@ -1,0 +1,243 @@
+package mysqloperatorcalculator
+
+import (
+	"strconv"
+	"testing"
+)
+
+// makeRequest builds a minimal valid ConfigurationRequest for integration tests.
+func makeRequest(dbtype string, dimID, loadID, connections int) ConfigurationRequest {
+	return ConfigurationRequest{
+		DBType:      dbtype,
+		Connections: connections,
+		Dimension:   Dimension{Id: dimID},
+		LoadType:    LoadType{Id: loadID},
+		Mysqlversion: Version{Major: 8, Minor: 0, Patch: 32},
+	}
+}
+
+// runCalculate is a shorthand: Init + GetCalculate.
+func runCalculate(req ConfigurationRequest) (error, ResponseMessage, map[string]Family) {
+	var conf Configuration
+	conf.Init()
+	var moc MysqlOperatorCalculator
+	moc.Init(req, conf)
+	return moc.GetCalculate()
+}
+
+// bufferPoolBytes extracts innodb_buffer_pool_size from the returned families.
+func bufferPoolBytes(t *testing.T, families map[string]Family) int64 {
+	t.Helper()
+	mysql, ok := families[FamilyTypeMysql]
+	if !ok {
+		t.Fatal("mysql family missing from response")
+	}
+	innodb, ok := mysql.Groups["configuration_innodb"]
+	if !ok {
+		t.Fatal("configuration_innodb group missing")
+	}
+	bp, ok := innodb.Parameters["innodb_buffer_pool_size"]
+	if !ok {
+		t.Fatal("innodb_buffer_pool_size missing")
+	}
+	val, err := strconv.ParseInt(bp.Value, 10, 64)
+	if err != nil {
+		t.Fatalf("cannot parse innodb_buffer_pool_size %q: %v", bp.Value, err)
+	}
+	return val
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path PXC
+// ---------------------------------------------------------------------------
+
+func TestIntegration_PXC_Small_MostlyReads_OK(t *testing.T) {
+	err, msg, families := runCalculate(makeRequest(DbTypePXC, 2, LoadTypeMostlyReads, 50))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType == OverutilizingI {
+		t.Errorf("expected Ok or CloseToLimit, got OverutilizingI: %s", msg.MText)
+	}
+	bp := bufferPoolBytes(t, families)
+	if bp <= 0 {
+		t.Errorf("innodb_buffer_pool_size must be > 0, got %d", bp)
+	}
+}
+
+func TestIntegration_PXC_Medium_HeavyOLTP_OK(t *testing.T) {
+	err, msg, families := runCalculate(makeRequest(DbTypePXC, 3, LoadTypeEqualReadsWrites, 200))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType == OverutilizingI {
+		t.Errorf("unexpected OverutilizingI: %s", msg.MText)
+	}
+	if bufferPoolBytes(t, families) <= 0 {
+		t.Error("innodb_buffer_pool_size must be > 0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path Group Replication
+// ---------------------------------------------------------------------------
+
+func TestIntegration_GR_Small_SomeWrites_OK(t *testing.T) {
+	err, msg, families := runCalculate(makeRequest(DbTypeGroupReplication, 2, LoadTypeSomeWrites, 100))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType == OverutilizingI {
+		t.Errorf("unexpected OverutilizingI: %s", msg.MText)
+	}
+
+	// GR must have the group_replication group with the GCS cache parameter
+	mysql := families[FamilyTypeMysql]
+	grGroup, ok := mysql.Groups["configuration_groupReplication"]
+	if !ok {
+		t.Fatal("configuration_groupReplication group missing for GR request")
+	}
+	gcs, ok := grGroup.Parameters["loose_group_replication_message_cache_size"]
+	if !ok {
+		t.Fatal("loose_group_replication_message_cache_size missing")
+	}
+	val, _ := strconv.ParseInt(gcs.Value, 10, 64)
+	if val <= 0 {
+		t.Errorf("loose_group_replication_message_cache_size must be > 0, got %d", val)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Saturation — XSmall + heavy load + many connections
+// ---------------------------------------------------------------------------
+
+func TestIntegration_PXC_XSmall_Saturated(t *testing.T) {
+	// XSmall (1 CPU, 2 GB) cannot handle 5000 heavy-write connections
+	err, msg, _ := runCalculate(makeRequest(DbTypePXC, 1, LoadTypeEqualReadsWrites, 5000))
+	if err != nil {
+		t.Fatalf("unexpected hard error: %v", err)
+	}
+	// Expect either OverutilizingI or ConnectionRecalculated (auto back-off)
+	if msg.MType != OverutilizingI && msg.MType != ConnectionRecalculated {
+		t.Errorf("expected saturation response, got MType=%d text=%s", msg.MType, msg.MText)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Invalid requests
+// ---------------------------------------------------------------------------
+
+func TestIntegration_MissingDimensionID(t *testing.T) {
+	req := makeRequest(DbTypePXC, 0, LoadTypeMostlyReads, 50) // dim ID 0 is invalid
+	err, _, _ := runCalculate(req)
+	if err == nil {
+		t.Error("expected error for missing dimension ID, got nil")
+	}
+}
+
+func TestIntegration_MissingLoadTypeID(t *testing.T) {
+	req := makeRequest(DbTypePXC, 2, 0, 50) // load ID 0 is invalid
+	err, _, _ := runCalculate(req)
+	if err == nil {
+		t.Error("expected error for missing load type ID, got nil")
+	}
+}
+
+func TestIntegration_InvalidDBType(t *testing.T) {
+	req := makeRequest("oracle", 2, LoadTypeMostlyReads, 50)
+	err, _, _ := runCalculate(req)
+	if err == nil {
+		t.Error("expected error for invalid DBType, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto-scale by connections (dimension ID 998)
+// ---------------------------------------------------------------------------
+
+func TestIntegration_AutoScaleByConnections(t *testing.T) {
+	req := makeRequest(DbTypePXC, ConnectionDimension, LoadTypeMostlyReads, 200)
+	err, msg, families := runCalculate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType != ResourcesRecalculated {
+		t.Errorf("expected ResourcesRecalculated, got MType=%d", msg.MType)
+	}
+	if bufferPoolBytes(t, families) <= 0 {
+		t.Error("innodb_buffer_pool_size must be > 0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Open dimension (ID 999)
+// ---------------------------------------------------------------------------
+
+func TestIntegration_OpenDimension_PXC(t *testing.T) {
+	req := ConfigurationRequest{
+		DBType:      DbTypePXC,
+		Connections: 100,
+		Dimension: Dimension{
+			Id:          DimensionOpen,
+			Cpu:         4000,
+			Memory:      "8GB",
+			MemoryBytes: 8 * 1024 * 1024 * 1024,
+		},
+		LoadType:     LoadType{Id: LoadTypeMostlyReads},
+		Mysqlversion: Version{Major: 8, Minor: 0, Patch: 32},
+	}
+	err, msg, families := runCalculate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType == OverutilizingI {
+		t.Errorf("unexpected OverutilizingI for open dimension: %s", msg.MText)
+	}
+	if bufferPoolBytes(t, families) <= 0 {
+		t.Error("innodb_buffer_pool_size must be > 0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resources group — probes and limits always present
+// ---------------------------------------------------------------------------
+
+func TestIntegration_ProbesAndResourcesPresent(t *testing.T) {
+	_, _, families := runCalculate(makeRequest(DbTypePXC, 2, LoadTypeMostlyReads, 50))
+
+	for _, familyName := range []string{FamilyTypeMysql, FamilyTypeProxy, FamilyTypeMonitor} {
+		fam, ok := families[familyName]
+		if !ok {
+			t.Errorf("family %q missing", familyName)
+			continue
+		}
+		for _, group := range []string{"resources", "readinessProbe", "livenessProbe"} {
+			g, ok := fam.Groups[group]
+			if !ok {
+				t.Errorf("family %q: group %q missing", familyName, group)
+				continue
+			}
+			if len(g.Parameters) == 0 {
+				t.Errorf("family %q group %q has no parameters", familyName, group)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MySQL version filtering
+// ---------------------------------------------------------------------------
+
+func TestIntegration_VersionFilter_OldVersion(t *testing.T) {
+	// MySQL 8.0.30 is below the minimum for some parameters (e.g. min 8.0.32)
+	req := makeRequest(DbTypePXC, 2, LoadTypeMostlyReads, 50)
+	req.Mysqlversion = Version{Major: 8, Minor: 0, Patch: 28}
+	err, _, families := runCalculate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Result must still be a valid, non-empty families map
+	if len(families) == 0 {
+		t.Error("families map should not be empty even for old MySQL version")
+	}
+}

--- a/src/mysqloperatorcalculator/integration_test.go
+++ b/src/mysqloperatorcalculator/integration_test.go
@@ -8,11 +8,11 @@ import (
 // makeRequest builds a minimal valid ConfigurationRequest for integration tests.
 func makeRequest(dbtype string, dimID, loadID, connections int) ConfigurationRequest {
 	return ConfigurationRequest{
-		DBType:      dbtype,
-		Connections: connections,
-		Dimension:   Dimension{Id: dimID},
-		LoadType:    LoadType{Id: loadID},
-		Mysqlversion: Version{Major: 8, Minor: 0, Patch: 32},
+		DBType:       dbtype,
+		Connections:  connections,
+		Dimension:    Dimension{Id: dimID},
+		LoadType:     LoadType{Id: loadID},
+		Mysqlversion: Version{Major: 8, Minor: 0, Patch: 46},
 	}
 }
 
@@ -184,7 +184,7 @@ func TestIntegration_OpenDimension_PXC(t *testing.T) {
 			MemoryBytes: 8 * 1024 * 1024 * 1024,
 		},
 		LoadType:     LoadType{Id: LoadTypeMostlyReads},
-		Mysqlversion: Version{Major: 8, Minor: 0, Patch: 32},
+		Mysqlversion: Version{Major: 8, Minor: 0, Patch: 46},
 	}
 	err, msg, families := runCalculate(req)
 	if err != nil {
@@ -229,9 +229,9 @@ func TestIntegration_ProbesAndResourcesPresent(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIntegration_VersionFilter_OldVersion(t *testing.T) {
-	// MySQL 8.0.30 is below the minimum for some parameters (e.g. min 8.0.32)
+	// 8.0.44 is below MySQLMinSupported (8.0.46) — most parameters get filtered out
 	req := makeRequest(DbTypePXC, 2, LoadTypeMostlyReads, 50)
-	req.Mysqlversion = Version{Major: 8, Minor: 0, Patch: 28}
+	req.Mysqlversion = Version{Major: 8, Minor: 0, Patch: 44}
 	err, _, families := runCalculate(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/src/mysqloperatorcalculator/mysqloperatorcalculator.go
+++ b/src/mysqloperatorcalculator/mysqloperatorcalculator.go
@@ -71,7 +71,7 @@ func (moc *MysqlOperatorCalculator) GetCalculate() (error, ResponseMessage, map[
 			moc.IncomingRequest.Dimension = dimension
 			calcErr, message, Families = moc.getCalculateInt()
 		}
-		message.MText += "\n!!!! Resources calculated to match connections request\n\n"
+		message.MText += "\n!!!! Minimal Resources needed to serve.\nCalculated to match connections request\n\n"
 		message.MName = message.GetMessageText(ResourcesRecalculated)
 		message.MType = ResourcesRecalculated
 	}
@@ -112,7 +112,8 @@ func (moc *MysqlOperatorCalculator) getCalculateInt() (error, ResponseMessage, m
 
 	// Handle pre-defined configs
 	if ConfRequest.Dimension.Id != 999 && ConfRequest.Dimension.Id != 998 && ConfRequest.Dimension.Name != "scaled" {
-		ConfRequest = getConfForConfRequest(ConfRequest, conf)
+		//ConfRequest = getConfForConfRequest(ConfRequest, conf)
+		moc.GetConfForConfRequest()
 	}
 
 	families := family.Init(ConfRequest.DBType)
@@ -136,27 +137,27 @@ func (moc *MysqlOperatorCalculator) getCalculateInt() (error, ResponseMessage, m
 	return nil, responseMsg, families
 }
 
-func getConfForConfRequest(request ConfigurationRequest, conf Configuration) ConfigurationRequest {
-	if request.Dimension.Id != DimensionOpen {
-		for i := range conf.Dimension {
-			if request.Dimension.Id == conf.Dimension[i].Id {
-				request.Dimension = conf.Dimension[i]
-				break
-			}
-		}
-	} else {
-		request.Dimension = conf.CalculateOpenDimension(request.Dimension)
-	}
-
-	for i := range conf.LoadType {
-		if request.LoadType.Id == conf.LoadType[i].Id {
-			request.LoadType = conf.LoadType[i]
-			break
-		}
-	}
-
-	return request
-}
+//func getConfForConfRequest(request ConfigurationRequest, conf Configuration) ConfigurationRequest {
+//	if request.Dimension.Id != DimensionOpen {
+//		for i := range conf.Dimension {
+//			if request.Dimension.Id == conf.Dimension[i].Id {
+//				request.Dimension = conf.Dimension[i]
+//				break
+//			}
+//		}
+//	} else {
+//		request.Dimension = conf.CalculateOpenDimension(request.Dimension)
+//	}
+//
+//	for i := range conf.LoadType {
+//		if request.LoadType.Id == conf.LoadType[i].Id {
+//			request.LoadType = conf.LoadType[i]
+//			break
+//		}
+//	}
+//
+//	return request
+//}
 
 func ReturnResponse(writer http.ResponseWriter, request *http.Request, ConfRequest *ConfigurationRequest, message ResponseMessage, families map[string]Family) error {
 	var b bytes.Buffer
@@ -262,7 +263,6 @@ func (moc *MysqlOperatorCalculator) GetConfForConfRequest() {
 	}
 
 	for i := range moc.Conf.LoadType {
-		// BUG FIX: Originally compared `Dimension.Id` against `LoadType[i].Id`.
 		if moc.IncomingRequest.LoadType.Id == moc.Conf.LoadType[i].Id {
 			moc.IncomingRequest.LoadType = moc.Conf.LoadType[i]
 			break

--- a/src/mysqloperatorcalculator/mysqloperatorcalculator.go
+++ b/src/mysqloperatorcalculator/mysqloperatorcalculator.go
@@ -44,7 +44,7 @@ func (moc *MysqlOperatorCalculator) GetCalculate() (error, ResponseMessage, map[
 	if ConfRequest.Dimension.Id == 0 || ConfRequest.LoadType.Id == 0 {
 		return fmt.Errorf("Possible Malformed request, Dimension ID: %d; LoadType ID: %d", ConfRequest.Dimension.Id, ConfRequest.LoadType.Id), responseMsg, families
 	} else if ConfRequest.Dimension.Id == DimensionOpen && (ConfRequest.Dimension.Cpu == 0 || ConfRequest.Dimension.MemoryBytes == 0) {
-		return fmt.Errorf("Open dimension request missing CPU OR Memory value CPU: %g, Memory %g", ConfRequest.Dimension.Cpu, ConfRequest.Dimension.Memory), responseMsg, families
+		return fmt.Errorf("Open dimension request missing CPU OR Memory value CPU: %d, Memory %s", ConfRequest.Dimension.Cpu, ConfRequest.Dimension.Memory), responseMsg, families
 	}
 
 	if ConfRequest.DBType != DbTypePXC && ConfRequest.DBType != DbTypeGroupReplication {
@@ -79,9 +79,18 @@ func (moc *MysqlOperatorCalculator) GetCalculate() (error, ResponseMessage, map[
 	// Auto calculation of the connections
 	if moc.IncomingRequest.Connections == 0 { //|| moc.IncomingRequest.Dimension.Id == DimensionOpen {
 		moc.IncomingRequest.Connections = MinConnectionNumber
-		for message.MType != OverutilizingI {
+		for message.MType != OverutilizingI && moc.IncomingRequest.Connections < MaxAutoConnections {
 			moc.IncomingRequest.Connections += 10
 			calcErr, message, Families = moc.getCalculateInt()
+		}
+		// We check the connections, and if it goes above the limit we stop and return an error message
+		if moc.IncomingRequest.Connections >= MaxAutoConnections {
+			log.Warnf("Auto-connection loop hit cap (%d), dimension may be undersized", MaxAutoConnections)
+			message.MType = ErrorexecI
+			message.MText = fmt.Sprintf(message.GetMessageText(ErrorexecI),
+				fmt.Sprintf("auto-connection discovery reached the cap of %d connections; the requested dimension may be undersized", MaxAutoConnections))
+			message.MName = "Auto-connection cap reached"
+			return calcErr, message, Families
 		}
 
 		moc.IncomingRequest.Connections -= 10

--- a/src/server.go
+++ b/src/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 
 	MO "github.com/Tusamarco/mysqloperatorcalculator/src/mysqloperatorcalculator"
 	log "github.com/sirupsen/logrus"
@@ -106,19 +107,28 @@ func handleGetCalculate(writer http.ResponseWriter, request *http.Request) error
 	var ConfRequest MO.ConfigurationRequest
 
 	//if we do not have a real request we return a message with the info
-	len := request.ContentLength
-	if len <= 0 {
+	if request.ContentLength == 0 {
 		err := returnErrorMessage(writer, request, ConfRequest, responseMsg, families, "Empty request")
 		if err != nil {
 			return err
 		}
 		return nil
 	}
-	body := make([]byte, len)
-	request.Body.Read(body)
-	//var buffer bytes.Buffer
-	//buffer.Write(body)
-	//println(buffer.String())
+	body, readErr := io.ReadAll(request.Body)
+	if readErr != nil {
+		err := returnErrorMessage(writer, request, ConfRequest, responseMsg, families, "Failed to read request body: "+readErr.Error())
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	if len(body) == 0 {
+		err := returnErrorMessage(writer, request, ConfRequest, responseMsg, families, "Empty request body")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// we need to process the request and get the values
 	err1 := json.Unmarshal(body, &ConfRequest)
@@ -184,8 +194,8 @@ func handleGetCalculate(writer http.ResponseWriter, request *http.Request) error
 }
 
 func exitWithCode(errorCode int) {
-	log.Debug("Exiting execution with code ", errorCode)
-	os.Exit(errorCode)
+	log.Debug("Error execution with code ", errorCode)
+	//os.Exit(errorCode)
 }
 
 func returnErrorMessage(writer http.ResponseWriter, request *http.Request, ConfRequest MO.ConfigurationRequest, message MO.ResponseMessage, families map[string]MO.Family, errorMessage string) error {

--- a/src/server.go
+++ b/src/server.go
@@ -76,7 +76,7 @@ func handleGetSupported(writer http.ResponseWriter, request *http.Request) error
 		return err
 	}
 
-	writer.Header().Set("Content/Type", "application/json")
+	writer.Header().Set("Content-Type", "application/json")
 	writer.Write(output)
 	return nil
 }
@@ -133,8 +133,11 @@ func handleGetCalculate(writer http.ResponseWriter, request *http.Request) error
 	// we need to process the request and get the values
 	err1 := json.Unmarshal(body, &ConfRequest)
 	if err1 != nil {
-		println(err1.Error())
-		exitWithCode(64)
+		err := returnErrorMessage(writer, request, ConfRequest, responseMsg, families, "Malformed JSON: "+err1.Error())
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 	if ConfRequest.Dimension.MemoryBytes == 0 && ConfRequest.Dimension.Id != 998 {
 		var errConv error
@@ -224,7 +227,7 @@ func ReturnResponse(writer http.ResponseWriter, request *http.Request, ConfReque
 	}
 
 	// Return the information
-	writer.Header().Set("Content/Type", "application/json")
+	writer.Header().Set("Content-Type", "application/json")
 	writer.Write(b.Bytes())
 	return nil
 }


### PR DESCRIPTION

server.go — request body reading
- Replace make([]byte, ContentLength) + Read() with io.ReadAll(), which handles
  chunked transfer encoding (ContentLength = -1) and guarantees a full read.
- Check and surface read errors instead of silently discarding them.
- Add post-read empty-body guard for the case where ContentLength is nonzero
  but the body arrives empty.
- Change ContentLength <= 0 guard to == 0 so chunked requests are no longer
  rejected before the body is read.
configurator.go — buffer pool calculation bug (GR)
- paramInnoDBBufferPool: bufferPoolSubstract was hardcoded to InnoDBPctValuePXC
  (0.80) even for Group Replication deployments. Now uses bufferPollPct, which
  is correctly set to InnoDBPctValueGR (0.70) for GR. This prevented the GCS
  cache from getting its reserved memory in GR configurations.
configurator.go — negative buffer pool floor
- In the negative-leftover branch of paramInnoDBBufferPool, add a minimum floor
  (MinLimitPXC or MinLimitGR of total MySQL memory) so the buffer pool cannot
  shrink below the saturation threshold when allocations exceed available memory.
configurator.go — load-type switch refactoring
- Add loadValues([4]string) and loadFloat([4]float64) helpers: single-switch
  dispatchers indexed [MostlyReads, SomeWrites, EqualReadsWrites, HeavyWrites].
- Replace 8 repeated switch-on-loadID blocks with calls to these helpers:
  getGcache footprint factor, calculateTmpTableFootprint multiplier,
  getGcacheLoad, paramBinlogCacheSize, paramJoinBuffer, paramReadRndBuffer,
  paramSortBuffer, paramInnoDBIOCapacityMax.
- Adding a new load type now requires changes in two helpers only, not 15 sites.
- getGcache previously used raw integer literals (case 1/2/3) instead of the
  LoadType* constants; now uses the named constants via loadFloat.
mysqloperatorcalculator.go — consolidate duplicate request resolution
- Remove standalone getConfForConfRequest() function; route all calls through
  the exported GetConfForConfRequest() method, eliminating the dual-path logic.
Constants.go — extract constants to dedicated file
- Move all package-level constants out of Configuration.go into Constants.go
  to separate data structure definitions from tuning values.
README.md — fix output format documentation
- Remove "default", "min", "max" fields from the JSON example snippet: the
  custom MarshalJSON on Parameter only emits "name" and "value"; the README
  was documenting fields that are never actually present in the response.
- Remove the claim that the human-readable format strips min/max/default
  (those fields were never in the JSON output to begin with).


Configuration.go — version boundary variables
- Remove the large commented-out const block that duplicated Constants.go;
  it was dead code and created noise in the file.
- Add package-level variables for the supported version range and all
  boundary points used across parameter definitions:
    MySQLMinSupported = Version{8, 0, 46}
    MySQLMaxSupported = Version{11, 1, 1}
    V8_0_46, V8_4_1, V11_1_1
- Using named vars instead of inline Version{x, y, z} literals eliminates
  the risk of positional confusion (Major/Minor/Patch order), makes every
  boundary point searchable, and means extending support to a new version
  requires a one-line change rather than hunting across 40+ definitions.
Configuration.go — updated parameter version ranges
- Raise the baseline range for all parameters from {8.0.30, 10.1.0} to
  {V8_0_46, V11_1_1}, tracking the minimum currently supported by Percona
  Operator and the current MySQL/PS innovation ceiling.
- Retain correct narrow ranges for parameters that were deprecated or
  replaced between minor versions:
    innodb_log_file_size / innodb_log_files_in_group:  {8.0.27, V8_0_46}
      (removed when innodb_redo_log_capacity superseded them at 8.0.31)
    innodb_redo_log_capacity:  {8.0.31, V11_1_1}
      (introduced at 8.0.31 as the replacement)
    innodb_io_capacity_max / innodb_numa_interleave:  {V8_0_46, 8.8.0}
      (removed in 8.8 / MySQL 9.x series)
    innodb_flush_log_at_trx_commit:  {V8_0_46, 10.2.0}
      (behaviour changed in 10.2 innovation series)
integration_test.go — align test versions with new minimum
- makeRequest helper and TestIntegration_OpenDimension_PXC were both
  sending Mysqlversion{8, 0, 32}, which is below the new minimum 8.0.46.
  filterByMySQLVersion was correctly stripping all version-bounded params
  (including innodb_buffer_pool_size), causing five integration tests to
  fail with "parameter missing" fatals. Bump both to {8, 0, 46}.
- TestIntegration_VersionFilter_OldVersion intentionally stays below the
  minimum (8.0.44) to exercise the filtering path; update the comment to
  state the actual current minimum rather than the old one.
All 48 tests pass after these changes.

- Added unit tests