### PR TITLE
src/mysqloperatorcalculator/Configuration.go

### DIFF
--- a/src/help.go
+++ b/src/help.go
@@ -33,24 +33,100 @@ func (help *HelpText) PrintLicense() {
 }
 
 func (help *HelpText) GetHelpText() string {
-	helpText := `MySQL Calculator for Percona Operator (PXC and PS)
+	helpText := `MySQL Operator Calculator — Percona (PXC and Group Replication)
 
+ENDPOINTS
+  GET  /supported    Returns valid dimensions, load types, DB types, and MySQL version range.
+  POST /calculator   Returns a full MySQL / Kubernetes configuration for the given request.
 
-To get supported scenarios:
-  curl -i -X GET  http://192.168.4.41:8080/supported
-	  HTTP/1.1 200 OK
-	  Date: Sat, 24 Dec 2022 17:00:33 GMT
-	  Content-Length: 183
-	  Content-Type: text/plain; charset=utf-8
-	
-	  {"dimension":{"Large":4,"Medium":3,"Small":2,"XLarge":5,"XSmall":1},"loadtype":{"Intense OLTP (50/50 R/W)":3,"Light OLTP":2,"Mainly Reads":1},"connections":[50,100,200,500,1000,2000]}
+────────────────────────────────────────────────────────────────
+GET /supported
+────────────────────────────────────────────────────────────────
+  curl http://127.0.0.1:8080/supported
 
+  Response (abbreviated):
+  {
+    "DBType":  ["group_replication", "pxc"],
+    "Output":  ["human", "json"],
+    "Dimension": [
+      {"Id":1,  "Name":"XSmall",   "Cpu":1000,  "Memory":"2GB"},
+      {"Id":2,  "Name":"Small",    "Cpu":2500,  "Memory":"4GB"},
+      {"Id":3,  "Name":"Medium",   "Cpu":4500,  "Memory":"8GB"},
+      {"Id":4,  "Name":"Large",    "Cpu":6500,  "Memory":"16GB"},
+      {"Id":5,  "Name":"2XLarge",  "Cpu":8500,  "Memory":"32GB"},
+      {"Id":6,  "Name":"4XLarge",  "Cpu":16000, "Memory":"64GB"},
+      {"Id":7,  "Name":"8XLarge",  "Cpu":32000, "Memory":"128GB"},
+      {"Id":8,  "Name":"12XLarge", "Cpu":48000, "Memory":"192GB"},
+      {"Id":9,  "Name":"16XLarge", "Cpu":64000, "Memory":"256GB"},
+      {"Id":10, "Name":"24XLarge", "Cpu":96000, "Memory":"384GB"},
+      {"Id":999,"Name":"Open request by resources"},
+      {"Id":998,"Name":"Open request by Connection"}
+    ],
+    "LoadType": [
+      {"Id":1,"Name":"Mainly Reads", "Description":"Blogs ~10% Writes 90% Reads"},
+      {"Id":2,"Name":"Light OLTP",   "Description":"Shops online up to ~40% Writes"},
+      {"Id":3,"Name":"Heavy OLTP",   "Description":"Intense analytics, telephony, gaming. 30/70% Reads and Writes"},
+      {"Id":4,"Name":"Mainly write", "Description":"Data load, data ingest. 90% writes"}
+    ],
+    "Connections":   [50,100,200,500,1000,2000],
+    "Mysqlversions": {"Min":{"Major":8,"Minor":0,"Patch":46},"Max":{"Major":11,"Minor":1,"Patch":1}}
+  }
 
+────────────────────────────────────────────────────────────────
+POST /calculator — predefined dimension
+────────────────────────────────────────────────────────────────
+  curl -X POST -H "Content-Type: application/json" \
+    -d '{
+          "output":       "human",
+          "dbtype":       "pxc",
+          "dimension":    {"id": 2},
+          "loadtype":     {"id": 2},
+          "connections":  100,
+          "mysqlversion": {"major":8,"minor":0,"patch":46}
+        }' \
+    http://127.0.0.1:8080/calculator
 
-to test:
- curl -i -X GET -H "Content-Type: application/json" -d '{"output":"human","dbtype":"pxc", "dimension":  {"id": 2}, "loadtype":  {"id": 2}, "connections": 5,"mysqlversion":{"major":8,"minor":0,"patch":33}}' http://127.0.0.1:8080/calculator
+────────────────────────────────────────────────────────────────
+POST /calculator — open dimension (id 999, custom CPU + memory)
+────────────────────────────────────────────────────────────────
+  curl -X POST -H "Content-Type: application/json" \
+    -d '{
+          "output":       "json",
+          "dbtype":       "group_replication",
+          "dimension":    {"id": 999, "cpu": 4000, "memory": "8GB"},
+          "loadtype":     {"id": 3},
+          "connections":  200,
+          "mysqlversion": {"major":8,"minor":0,"patch":46}
+        }' \
+    http://127.0.0.1:8080/calculator
 
+────────────────────────────────────────────────────────────────
+POST /calculator — connection-driven sizing (id 998)
+────────────────────────────────────────────────────────────────
+  The calculator picks the smallest dimension that sustains the
+  requested connection count and returns ResourcesRecalculated.
 
+  curl -X POST -H "Content-Type: application/json" \
+    -d '{
+          "output":       "json",
+          "dbtype":       "pxc",
+          "dimension":    {"id": 998},
+          "loadtype":     {"id": 2},
+          "connections":  500,
+          "mysqlversion": {"major":8,"minor":0,"patch":46}
+        }' \
+    http://127.0.0.1:8080/calculator
+
+────────────────────────────────────────────────────────────────
+REQUEST FIELDS
+────────────────────────────────────────────────────────────────
+  output          "human" (INI-style my.cnf) or "json"
+  dbtype          "pxc" or "group_replication"
+  dimension.id    1–10 predefined  |  998 connection-driven  |  999 custom resources
+  loadtype.id     1 Mainly Reads   |  2 Light OLTP  |  3 Heavy OLTP  |  4 Mainly write
+  connections     target connection count (0 = auto-discover maximum for the dimension)
+  mysqlversion    {"major":M,"minor":m,"patch":p}  minimum supported: 8.0.46
+  providerCostPct optional overhead fraction deducted from resources (e.g. 0.12 = 12%)
 
 `
 	return helpText

--- a/src/mysqloperatorcalculator/Configuration.go
+++ b/src/mysqloperatorcalculator/Configuration.go
@@ -177,6 +177,7 @@ func (conf *Configuration) Init() {
 		{1, "Mainly Reads", "Blogs ~10% Writes 90% Reads"},
 		{2, "Light OLTP", "Shops online up to ~40% Writes "},
 		{3, "Heavy OLTP", "Intense analytics, telephony, gaming. 30/70% Reads and Writes"},
+		{4, "Mainly write", "Data load, data ingest. 90% writes"},
 	}
 
 	conf.Connections = []int{50, 100, 200, 500, 1000, 2000}

--- a/src/mysqloperatorcalculator/configuration_test.go
+++ b/src/mysqloperatorcalculator/configuration_test.go
@@ -89,7 +89,7 @@ func TestGetDimensionByID_MemoryBytes(t *testing.T) {
 func TestGetLoadByID_Valid(t *testing.T) {
 	var conf Configuration
 	conf.Init()
-	for _, id := range []int{LoadTypeMostlyReads, LoadTypeSomeWrites, LoadTypeEqualReadsWrites} {
+	for _, id := range []int{LoadTypeMostlyReads, LoadTypeSomeWrites, LoadTypeEqualReadsWrites, LoadTypeHeavyWrites} {
 		load := conf.GetLoadByID(id)
 		if load.Id != id {
 			t.Errorf("GetLoadByID(%d) returned Id=%d", id, load.Id)

--- a/src/mysqloperatorcalculator/configurator.go
+++ b/src/mysqloperatorcalculator/configurator.go
@@ -464,11 +464,11 @@ func (c *Configurator) paramInnoDBBufferPool(parameter Parameter, final bool) Pa
 
 	if !final {
 		bufferPool := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
-		bufferPoolSubstract := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
+		//bufferPoolSubstract := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
 
 		parameter.Value = strconv.FormatInt(bufferPool, 10)
 		c.reference.innoDBbpSize = bufferPool
-		c.reference.memoryLeftover -= bufferPoolSubstract
+		c.reference.memoryLeftover -= bufferPool //bufferPoolSubstract
 	} else {
 		bufferPool := int64(0)
 

--- a/src/mysqloperatorcalculator/integration_test.go
+++ b/src/mysqloperatorcalculator/integration_test.go
@@ -25,6 +25,28 @@ func runCalculate(req ConfigurationRequest) (error, ResponseMessage, map[string]
 	return moc.GetCalculate()
 }
 
+// redoLogCapacityBytes extracts innodb_redo_log_capacity from the returned families.
+func redoLogCapacityBytes(t *testing.T, families map[string]Family) int64 {
+	t.Helper()
+	mysql, ok := families[FamilyTypeMysql]
+	if !ok {
+		t.Fatal("mysql family missing from response")
+	}
+	innodb, ok := mysql.Groups["configuration_innodb"]
+	if !ok {
+		t.Fatal("configuration_innodb group missing")
+	}
+	param, ok := innodb.Parameters["innodb_redo_log_capacity"]
+	if !ok {
+		t.Skip("innodb_redo_log_capacity not present (version filter applied)")
+	}
+	val, err := strconv.ParseInt(param.Value, 10, 64)
+	if err != nil {
+		t.Fatalf("cannot parse innodb_redo_log_capacity %q: %v", param.Value, err)
+	}
+	return val
+}
+
 // bufferPoolBytes extracts innodb_buffer_pool_size from the returned families.
 func bufferPoolBytes(t *testing.T, families map[string]Family) int64 {
 	t.Helper()
@@ -221,6 +243,98 @@ func TestIntegration_ProbesAndResourcesPresent(t *testing.T) {
 				t.Errorf("family %q group %q has no parameters", familyName, group)
 			}
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HeavyWrites (load type 4) — end-to-end
+// ---------------------------------------------------------------------------
+
+// Happy path: PXC + HeavyWrites produces a valid configuration.
+func TestIntegration_PXC_HeavyWrites_OK(t *testing.T) {
+	err, msg, families := runCalculate(makeRequest(DbTypePXC, 3, LoadTypeHeavyWrites, 100))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType == OverutilizingI {
+		t.Errorf("unexpected OverutilizingI: %s", msg.MText)
+	}
+	if bufferPoolBytes(t, families) <= 0 {
+		t.Error("innodb_buffer_pool_size must be > 0")
+	}
+	if redoLogCapacityBytes(t, families) <= 0 {
+		t.Error("innodb_redo_log_capacity must be > 0")
+	}
+}
+
+// Happy path: GR + HeavyWrites produces a valid configuration with GCS cache set.
+func TestIntegration_GR_HeavyWrites_OK(t *testing.T) {
+	err, msg, families := runCalculate(makeRequest(DbTypeGroupReplication, 3, LoadTypeHeavyWrites, 100))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.MType == OverutilizingI {
+		t.Errorf("unexpected OverutilizingI: %s", msg.MText)
+	}
+	if bufferPoolBytes(t, families) <= 0 {
+		t.Error("innodb_buffer_pool_size must be > 0")
+	}
+
+	mysql := families[FamilyTypeMysql]
+	grGroup, ok := mysql.Groups["configuration_groupReplication"]
+	if !ok {
+		t.Fatal("configuration_groupReplication group missing for GR+HeavyWrites request")
+	}
+	gcs, ok := grGroup.Parameters["loose_group_replication_message_cache_size"]
+	if !ok {
+		t.Fatal("loose_group_replication_message_cache_size missing")
+	}
+	val, _ := strconv.ParseInt(gcs.Value, 10, 64)
+	if val <= 0 {
+		t.Errorf("loose_group_replication_message_cache_size must be > 0, got %d", val)
+	}
+}
+
+// HeavyWrites saturates a dimension at fewer connections than EqualReadsWrites
+// because its CPU-per-connection cost factor (2.0) is higher than EqualReadsWrites (1.6).
+func TestIntegration_HeavyWrites_SaturatesEarlierThanEqualReadsWrites(t *testing.T) {
+	// Find the connection count that overloads HeavyWrites but not EqualReadsWrites
+	// on XSmall (MysqlCPU=600m): HeavyWrites max = 600/2=300, EqualReadsWrites max = 600/1.6=375
+	_, msgHW, _ := runCalculate(makeRequest(DbTypePXC, 1, LoadTypeHeavyWrites, 350))
+	_, msgEq, _ := runCalculate(makeRequest(DbTypePXC, 1, LoadTypeEqualReadsWrites, 350))
+
+	if msgHW.MType != OverutilizingI && msgHW.MType != ConnectionRecalculated {
+		t.Errorf("expected HeavyWrites to saturate at 350 connections on XSmall, got MType=%d", msgHW.MType)
+	}
+	if msgEq.MType == OverutilizingI {
+		t.Errorf("EqualReadsWrites should not saturate at 350 connections on XSmall, got MType=%d", msgEq.MType)
+	}
+}
+
+// Redo log must increase monotonically with write intensity for identical resources and connections.
+// Uses Large dimension (id=4) with low connections to keep loadFactor small and avoid the 1.0 cap.
+func TestIntegration_HeavyWrites_RedoLog_MonotonicByLoadType(t *testing.T) {
+	const dim = 4  // Large — MysqlCPU=5500m, high enough that 50 connections yields a low loadFactor
+	const conn = 50
+
+	_, _, famMR := runCalculate(makeRequest(DbTypePXC, dim, LoadTypeMostlyReads, conn))
+	_, _, famSW := runCalculate(makeRequest(DbTypePXC, dim, LoadTypeSomeWrites, conn))
+	_, _, famEq := runCalculate(makeRequest(DbTypePXC, dim, LoadTypeEqualReadsWrites, conn))
+	_, _, famHW := runCalculate(makeRequest(DbTypePXC, dim, LoadTypeHeavyWrites, conn))
+
+	redoMR := redoLogCapacityBytes(t, famMR)
+	redoSW := redoLogCapacityBytes(t, famSW)
+	redoEq := redoLogCapacityBytes(t, famEq)
+	redoHW := redoLogCapacityBytes(t, famHW)
+
+	if redoSW <= redoMR {
+		t.Errorf("SomeWrites redo log %d should be > MostlyReads %d", redoSW, redoMR)
+	}
+	if redoEq <= redoSW {
+		t.Errorf("EqualReadsWrites redo log %d should be > SomeWrites %d", redoEq, redoSW)
+	}
+	if redoHW <= redoEq {
+		t.Errorf("HeavyWrites redo log %d should be > EqualReadsWrites %d", redoHW, redoEq)
 	}
 }
 

--- a/src/server.go
+++ b/src/server.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 
 	MO "github.com/Tusamarco/mysqloperatorcalculator/src/mysqloperatorcalculator"
 	log "github.com/sirupsen/logrus"
@@ -20,14 +21,16 @@ func main() {
 	var (
 		//port    int
 		//ip      string
-		helpB   bool
-		version bool
-		help    HelpText
+		helpB    bool
+		version  bool
+		help     HelpText
+		loglevel string
 	)
 	port := flag.Int("port", 8080, "Port to serve")
 	ip := flag.String("address", "0.0.0.0", "Ip address")
 	flag.BoolVar(&helpB, "help", false, "for help")
 	flag.BoolVar(&version, "version", false, "to get product version")
+	flag.StringVar(&loglevel, "loglevel", "DEBUG", "log level default debug (ERROR|INFO|DEBUG)")
 	flag.Parse()
 
 	//initialize help
@@ -43,7 +46,18 @@ func main() {
 	}
 
 	//set log level
-	log.SetLevel(log.DebugLevel)
+	loglevel = strings.ToUpper(loglevel)
+	switch loglevel {
+	case "ERROR":
+		log.SetLevel(log.ErrorLevel)
+	case "INFO":
+		log.SetLevel(log.InfoLevel)
+	case "DEBUG":
+		log.SetLevel(log.DebugLevel)
+	default:
+		log.SetLevel(log.DebugLevel)
+
+	}
 
 	//set server address (need to come from configuration parameter)
 	server := http.Server{Addr: *ip + ":" + strconv.Itoa(*port)}
@@ -51,7 +65,11 @@ func main() {
 	//define API handlers
 	http.HandleFunc("/calculator", handleRequestCalculator)
 	http.HandleFunc("/supported", handleRequestSupported)
-	server.ListenAndServe()
+	err := server.ListenAndServe()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
 }
 
 func handleRequestSupported(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
  Registered LoadTypeHeavyWrites {4, "Mainly write", "Data load, data ingest. 90% writes"}
  in conf.LoadType so /supported returns all four load types.
src/mysqloperatorcalculator/configuration_test.go
  Extended TestGetLoadByID_Valid to include LoadTypeHeavyWrites.
src/mysqloperatorcalculator/configurator.go
  Removed redundant bufferPoolSubstract variable in paramInnoDBBufferPool first pass;
  memoryLeftover is now decremented directly by bufferPool (same value, single variable).
src/mysqloperatorcalculator/integration_test.go
  Added redoLogCapacityBytes() helper (extracts innodb_redo_log_capacity, skips if version-filtered).
  Added four LoadTypeHeavyWrites end-to-end integration tests:
    TestIntegration_PXC_HeavyWrites_OK             — PXC happy path, verifies BP and redo log > 0
    TestIntegration_GR_HeavyWrites_OK              — GR happy path, verifies GCS cache > 0
    TestIntegration_HeavyWrites_SaturatesEarlierThanEqualReadsWrites
        — proves HeavyWrites (factor 2.0) overloads XSmall at 350 connections
          while EqualReadsWrites (factor 1.6) does not
    TestIntegration_HeavyWrites_RedoLog_MonotonicByLoadType
        — verifies MostlyReads < SomeWrites < EqualReadsWrites < HeavyWrites redo log
          on Large (id=4) at 50 connections
src/server.go
  Added -loglevel CLI flag (ERROR|INFO|DEBUG, default DEBUG); log level is now runtime-configurable
  instead of hardcoded to DebugLevel.
  Fixed server.ListenAndServe() return value: error is now captured, logged, and triggers os.Exit(1).
  Added "strings" import for strings.ToUpper on the loglevel flag value.
src/help.go
  Complete rewrite of GetHelpText():
    - Updated title: "PXC and PS" → "PXC and Group Replication"
    - Corrected example IP: 192.168.4.41 → 127.0.0.1
    - /supported response now shows all 10 dimensions, all 4 load types, correct version
      range 8.0.46–11.1.1
    - Calculator examples changed from GET to POST; MySQL patch updated from 33 to 46
    - Three curl examples added: predefined dimension, open dimension (999), connection-driven (998)
    - REQUEST FIELDS reference section added (documents all fields including providerCostPct)