### PR TITLE
FR-27 — Add async replication (source/replica) as a supported DB type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The **MySQL Operator Calculator** is a robust Go library designed to dynamically calculate the optimal configurations, Kubernetes resource requests, and limits for MySQL deployments. Built specifically with Kubernetes Operators in mind, it analyzes target hardware dimensions, expected connections, and load profiles to generate highly tuned configurations for **MySQL**, **HAProxy (Proxy)**, and **Percona Monitoring and Management (Monitor)**.
 
-It supports both **Percona XtraDB Cluster (Galera / PXC)** and **MySQL Group Replication**, taking into account version-specific parameters and the hidden memory footprints of various MySQL internal structures (like GCache, GCS Cache, connection buffers, and temporary tables).
+It supports **Percona XtraDB Cluster (Galera / PXC)**, **MySQL Group Replication**, and **classic asynchronous source/replica replication**, taking into account version-specific parameters and the hidden memory footprints of various MySQL internal structures (like GCache, GCS Cache, connection buffers, and temporary tables).
 
 ### What It Does
 Given a set of total available resources (CPU/memory), a workload pattern, target connection count, and MySQL version, it generates:
@@ -32,7 +32,7 @@ All parameters are passed as a JSON payload to the `/calculator` endpoint or via
 | Parameter | Type | Required | Description |
 |:---|:---|:---:|:---|
 | `output` | `string` | **Yes** | `"json"` (structured) or `"human"` (my.cnf‑like text) |
-| `dbtype` | `string` | **Yes** | `"pxc"` or `"group_replication"` |
+| `dbtype` | `string` | **Yes** | `"pxc"`, `"group_replication"`, or `"async"` |
 | `dimension.id` | `int` | **Yes** | Pre‑defined ID (`1`…`n`), `998` (auto‑dimension by connections), or `999` (open request) |
 | `dimension.cpu` | `int` | *Cond.* | Required if `id=999`. Total CPU in millicores (e.g., `4000` = 4 full cores) |
 | `dimension.memory` | `string` | *Cond.* | Required if `id=999`. Total memory (e.g., `"2.5G"`, `"4096Mi"`, `"4GB"`) |
@@ -93,24 +93,27 @@ Three families are always present: `monitor`, `mysql`, and `proxy`. Each family 
 
 ---
 
-## ⚖️ PXC vs. Group Replication
+## ⚖️ PXC vs. Group Replication vs. Async
 
-The calculator treats PXC and Group Replication differently because their internal caches have distinct memory consumption patterns.
+The calculator treats each replication type differently because their internal caches have distinct memory consumption patterns.
 
-| Aspect | PXC (Galera) | Group Replication |
-|:---|:---|:---|
-| **InnoDB Buffer Pool ceiling** | Up to **80%** of MySQL memory | Up to **70%** of MySQL memory |
-| **Reasoning** | Galera’s GCache footprint is relatively small and stable. | GR’s **certification cache** can bloat during long transactions, risking OOM kills. |
-| **Min. InnoDB Memory floor** | `0.50` (50% of total dimension memory; ~62% of MySQL memory) | `0.40` (40% of total dimension memory; ~50% of MySQL memory) |
-| **Fixed GCS overhead** | N/A | 50 MiB reserved for the GR message-cache structure |
-| **Tuning Constants** | `GcacheFootPrintFactorRead = 0.5`, etc. | Additional `GroupRepGCSCacheMemStructureCost` reserved. |
+| Aspect | PXC (Galera) | Group Replication | Async (source/replica) |
+|:---|:---|:---|:---|
+| **InnoDB Buffer Pool ceiling** | Up to **80%** of MySQL memory | Up to **70%** of MySQL memory | Up to **82%** of MySQL memory |
+| **Reasoning** | Galera’s GCache footprint is relatively small and stable. | GR’s **certification cache** can bloat during long transactions, risking OOM kills. | No cluster caches compete; ceiling stays conservative so the node is safe while applying relay logs. |
+| **Min. InnoDB Memory floor** | `0.50` (50% of total dimension memory) | `0.40` (40% of total dimension memory) | `0.52` (52% of total dimension memory) |
+| **Fixed cluster overhead** | GCache footprint (load-dependent) | 50 MiB `GroupRepGCSCacheMemStructureCost` + per-connection GCS weight | None |
+| **Tuning Constants** | `GcacheFootPrintFactorRead = 0.5`, etc. | `GroupRepGCSCacheMemStructureCost`, `GCSConnWeight` | `InnoDBPctValueAsync`, `MinLimitAsync` |
+| **Role model** | All cluster nodes are symmetric | All cluster nodes are symmetric | Role-agnostic: same config is valid for source or replica; the Operator flips `read_only`/`super_read_only` at runtime |
 
 These constraints are mapped directly in the code:
 ```go
-InnoDBPctValuePXC  = 0.80
-InnoDBPctValueGR   = 0.70
-MinLimitPXC        = 0.50
-MinLimitGR         = 0.40
+InnoDBPctValuePXC   = 0.80
+InnoDBPctValueGR    = 0.70
+InnoDBPctValueAsync = 0.82
+MinLimitPXC         = 0.50
+MinLimitGR          = 0.40
+MinLimitAsync       = 0.52
 ```
 
 ---
@@ -297,7 +300,7 @@ curl -X GET http://127.0.0.1:8080/supported
 
 ```json
 {
-  "dbtype": [ "group_replication", "pxc" ],
+  "dbtype": [ "async", "group_replication", "pxc" ],
   "dimension": [
     { "id": 1, "name": "XSmall", "cpu": 1000, "memory": 2 },
     ...
@@ -651,8 +654,10 @@ All tuning knobs are defined in `src/mysqloperatorcalculator/Constants.go`. The 
 |:---|:---:|:---|
 | `InnoDBPctValuePXC` | `0.80` | Maximum fraction of MySQL memory that may be given to InnoDB buffer pool in PXC. Galera GCache is stable and small, so a higher ceiling is safe. |
 | `InnoDBPctValueGR` | `0.70` | Same ceiling for Group Replication. GR's certification cache can spike during long writes; a lower ceiling prevents OOM kills. |
+| `InnoDBPctValueAsync` | `0.82` | Ceiling for async replication. No cluster caches compete for memory, so a slightly higher ceiling is safe — kept conservative so a replica node is safe while applying relay logs. |
 | `MinLimitPXC` | `0.50` | Used in two ways: (1) hard floor — buffer pool will not shrink below 50% of MySQL-allocated memory; (2) response evaluation threshold — `OverutilizingI` is returned if the buffer pool falls below 50% of total dimension memory. |
 | `MinLimitGR` | `0.40` | Same dual role for Group Replication. Set lower than PXC because GR needs more headroom for certification and message caches. |
+| `MinLimitAsync` | `0.52` | Same dual role for async replication. Set higher than GR because no cluster caches compete, so a higher floor is achievable. |
 | `MemoryFreeMinimumLimit` | `0.02` | 2% of MySQL memory reserved and never allocated, as a safety margin for OS paging and allocator overhead. |
 
 ### Group Replication GCS cache
@@ -661,6 +666,17 @@ All tuning knobs are defined in `src/mysqloperatorcalculator/Constants.go`. The 
 |:---|:---:|:---|
 | `GroupRepGCSCacheMemStructureCost` | `52428800` (50 MiB) | Fixed overhead for the GR message-cache data structure, deducted from MySQL memory before buffer pool sizing. Separate from the per-connection cost. |
 | `GCSConnWeight` | `10` | Bytes per connection assumed for the GR message cache. Multiplied by `max_connections` to estimate total GCS memory demand. |
+
+### Binlog cache sizing (async only)
+
+Per-connection binlog cache size scales with write intensity. Monitor `Binlog_cache_use` and `Binlog_cache_disk_use` status variables; if disk use is non-zero, increase the value for your load type.
+
+| Constant | Value | Load type |
+|:---|:---:|:---|
+| `BinlogCacheSizeRead` | `32768` (32 KiB) | Mostly reads — transactions are small and infrequent |
+| `BinlogCacheSizeLightWrite` | `131072` (128 KiB) | Light OLTP — moderate transaction sizes |
+| `BinlogCacheSizeHeavyOLTP` | `262144` (256 KiB) | Heavy OLTP — mixed large transactions |
+| `BinlogCacheSizeHeavyWrite` | `524288` (512 KiB) | Bulk writes — large batches that must not spill to disk |
 
 ### GCache footprint factors (PXC only)
 
@@ -770,13 +786,15 @@ The result is written to both `innodb_redo_log_capacity` (MySQL 8.0.31+) and the
 ### Phase 3 — Buffer Pool (First Pass)
 
 ```
-bufferPool     = memoryLeftover × InnoDBPctValue   (0.80 PXC / 0.70 GR)
+bufferPool     = memoryLeftover × InnoDBPctValue   (0.80 PXC / 0.70 GR / 0.82 async)
 memoryLeftover -= bufferPool
 ```
 
 After this step `memoryLeftover` holds only the non-InnoDB portion — approximately 20–30% of MySQL memory — available for GCache, GCS, and other structures.
 
 ### Phase 4 — GCache / GCS Cache
+
+> **Async note:** this phase is skipped entirely for `dbtype = "async"`. There is no GCache or GCS structure, so the full `memoryLeftover` from Phase 3 remains available for the buffer pool recovery in Phase 7.
 
 **PXC only — GCache:**
 ```
@@ -818,6 +836,21 @@ The GCS cache is connection-driven: more connections relative to CPU means a pro
 
 **Group Replication parameters:**
 `loose_group_replication_member_expel_timeout` and `autorejoin_tries` are scaled up with `loadFactor` (busier nodes need more tolerance). `flow_control_period` scales inversely — lower on busy clusters. `communication_max_message_size` is reduced as dimension size increases (larger instances serve more concurrent transactions, so smaller messages reduce head-of-line blocking).
+
+**Async replication parameters (`configuration_async` group):**
+
+| Parameter | Tuning logic |
+|:---|:---|
+| `binlog_format` | Always `ROW` — required for GTID-based replication and downstream consumers. |
+| `binlog_row_image` | `MINIMAL` for mostly-reads; `FULL` for all write-bearing loads (safe for conflict detection and downstream GR consumers). |
+| `binlog_expire_logs_seconds` | `604800` (7 days) for read/light-write loads; `432000` (5 days) for heavy OLTP; `259200` (3 days) for heavy writes, to bound disk usage. |
+| `gtid_mode` | Always `ON` — enables crash-safe, position-independent failover. |
+| `enforce_gtid_consistency` | Always `ON` — rejects statements that cannot be logged safely in GTID mode. |
+| `innodb_flush_log_at_trx_commit` | Forced to `1` — any node may be promoted to source, so full ACID durability is required. |
+| `sync_relay_log` | Default (`10000`) on read/light-write loads; halved on heavy OLTP; reduced to one-third on heavy writes for crash-safety vs. throughput balance. |
+| `replica_net_timeout` | Base 60 s, scaled up with `loadFactor`: `ceil(60 × (1 + loadFactor))`. |
+| `replica_checkpoint_period` | Base 300 ms; reduced to 80% for heavy OLTP and 70% for heavy writes so the SQL thread checkpoints more frequently under sustained load. |
+| `relay_log_space_limit` | `0` (unlimited) by default; set explicitly in your deployment to bound relay log disk usage. |
 
 ### Phase 7 — Buffer Pool (Second Pass — Recovery or Shrinkage)
 
@@ -868,7 +901,7 @@ if bpPct < MinLimit + 0.10:   → ClosetolimitI
 else:                         → OkI
 ```
 
-`MinLimit` is `MinLimitPXC` (0.50) for PXC and `MinLimitGR` (0.40) for Group Replication. These thresholds are expressed as fractions of **total dimension memory** (not MySQL-allocated memory).
+`MinLimit` is `MinLimitPXC` (0.50) for PXC, `MinLimitGR` (0.40) for Group Replication, and `MinLimitAsync` (0.52) for async replication. These thresholds are expressed as fractions of **total dimension memory** (not MySQL-allocated memory).
 
 ### Outer Orchestration Loops
 

--- a/src/mysqloperatorcalculator/Configuration.go
+++ b/src/mysqloperatorcalculator/Configuration.go
@@ -156,7 +156,7 @@ func (respM *ResponseMessage) GetMessageText(id int) string {
 }
 
 func (conf *Configuration) Init() {
-	conf.DBType = []string{DbTypeGroupReplication, DbTypePXC}
+	conf.DBType = []string{DbTypeGroupReplication, DbTypePXC, DbTypeAsync}
 	conf.Output = []string{ResultOutputFormatHuman, ResultOutputFormatJson}
 	conf.Dimension = []Dimension{
 		{1, "XSmall", 1000, "2GB", 2147483648, 600, 200, 100, 1825361100, 214748364, 107374182},
@@ -186,6 +186,8 @@ func (conf *Configuration) Init() {
 
 func (family *Family) Init(DBTypeRequest string) map[string]Family {
 	// Group declarations shortened for brevity, functionally identical
+	asyncGroup := map[string]Parameter{}
+
 	replicaGroup := map[string]Parameter{
 		"replica_compressed_protocol":   {"replica_compressed_protocol", "configuration", "replication", "1", "1", 0, 1, MySQLVersions{V8_0_46, V11_1_1}},
 		"replica_exec_mode":             {"replica_exec_mode", "configuration", "replication", "STRICT", "STRICT", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
@@ -269,6 +271,28 @@ func (family *Family) Init(DBTypeRequest string) map[string]Family {
 		}},
 	}
 
+	if DBTypeRequest == DbTypeAsync {
+		// Source-side binlog tuning — valid on any node (any node may be promoted).
+		connectionGroup["binlog_cache_size"] = Parameter{"binlog_cache_size", "configuration", "connection", "131072", "32768", 4096, 0, MySQLVersions{V8_0_46, V11_1_1}}
+		connectionGroup["binlog_stmt_cache_size"] = Parameter{"binlog_stmt_cache_size", "configuration", "connection", "131072", "32768", 4096, 0, MySQLVersions{V8_0_46, V11_1_1}}
+
+		serverGroup["binlog_format"] = Parameter{"binlog_format", "configuration", "server", "ROW", "ROW", 0, 0, MySQLVersions{V8_0_46, V11_1_1}}
+		serverGroup["binlog_row_image"] = Parameter{"binlog_row_image", "configuration", "server", "FULL", "FULL", 0, 0, MySQLVersions{V8_0_46, V11_1_1}}
+		serverGroup["binlog_expire_logs_seconds"] = Parameter{"binlog_expire_logs_seconds", "configuration", "server", "604800", "604800", 0, 0, MySQLVersions{V8_0_46, V11_1_1}}
+
+		// GTID — hardcoded requirement (FR gap #1); emitted to avoid silent misconfig.
+		serverGroup["gtid_mode"] = Parameter{"gtid_mode", "configuration", "server", "ON", "ON", 0, 0, MySQLVersions{V8_0_46, V11_1_1}}
+		serverGroup["enforce_gtid_consistency"] = Parameter{"enforce_gtid_consistency", "configuration", "server", "ON", "ON", 0, 0, MySQLVersions{V8_0_46, V11_1_1}}
+
+		// Replica/apply-side group — valid on any node (any node may demote).
+		asyncGroup = map[string]Parameter{
+			"relay_log_space_limit":     {"relay_log_space_limit", "configuration", "async", "0", "0", 0, 0, MySQLVersions{V8_0_46, V11_1_1}},
+			"sync_relay_log":            {"sync_relay_log", "configuration", "async", "0", "10000", 0, 100000, MySQLVersions{V8_0_46, V11_1_1}},
+			"replica_net_timeout":       {"replica_net_timeout", "configuration", "async", "60", "60", 1, 0, MySQLVersions{V8_0_46, V11_1_1}},
+			"replica_checkpoint_period": {"replica_checkpoint_period", "configuration", "async", "300", "300", 1, 0, MySQLVersions{V8_0_46, V11_1_1}},
+		}
+	}
+
 	haproxyGroups := map[string]GroupObj{
 		"readinessProbe": {"readinessProbe", map[string]Parameter{"timeoutSeconds": {"timeoutSeconds", "", "readinessProbe", "5", "5", 5, 30, MySQLVersions{}}}},
 		"livenessProbe":  {"livenessProbe", map[string]Parameter{"timeoutSeconds": {"timeoutSeconds", "", "readinessProbe", "5", "5", 5, 60, MySQLVersions{}}}},
@@ -309,6 +333,10 @@ func (family *Family) Init(DBTypeRequest string) map[string]Family {
 
 	if DBTypeRequest == DbTypeGroupReplication {
 		mysqlGroups["configuration_groupReplication"] = GroupObj{"groupReplication", groupReplicationGroup}
+	}
+
+	if DBTypeRequest == DbTypeAsync {
+		mysqlGroups["configuration_async"] = GroupObj{"async", asyncGroup}
 	}
 
 	return map[string]Family{

--- a/src/mysqloperatorcalculator/Constants.go
+++ b/src/mysqloperatorcalculator/Constants.go
@@ -166,6 +166,25 @@ const (
 	BinlogCacheSizeHeavyWrite = "524288" // 512 KiB — bulk write
 
 	// ---------------------------------------------------------------------------
+	// Per connection buffers
+	// ---------------------------------------------------------------------------
+	JoinBufferSizeRead = "262144"
+	JoinBufferSizeLightWrite = "524288"
+	JoinBufferSizeHeavyOLTP = "1048576"
+	JoinBufferSizeHeavyWrite = "1048576"
+
+	ReadRndBufferSizeRead = "262144"
+	ReadRndBufferSizeLightWrite = "393216"
+	ReadRndBufferSizeHeavyOLTP = "707788"
+	ReadRndBufferSizeHeavyWrite = "707788"
+
+	SortBufferSizeRead = "262144"
+	SortBufferSizeLightWrite = "524288"
+	SortBufferSizeHeavyOLTP = "1572864"
+	SortBufferSizeHeavyWrite = "2097152"
+
+
+	// ---------------------------------------------------------------------------
 	// Auto-scale stepping increments (used when dimension.id = 998)
 	// These control how coarsely the dimension search steps through resource levels.
 	// ---------------------------------------------------------------------------

--- a/src/mysqloperatorcalculator/Constants.go
+++ b/src/mysqloperatorcalculator/Constants.go
@@ -69,6 +69,11 @@ const (
 
 	DbTypePXC              = "pxc"               // Percona XtraDB Cluster (Galera-based synchronous replication)
 	DbTypeGroupReplication = "group_replication" // MySQL Group Replication (InnoDB Cluster)
+	// DbTypeAsync is classic asynchronous source/replica replication. It is
+	// role-agnostic: the same configuration is valid whether the node currently
+	// acts as source or replica, because the Operator assigns and flips the role
+	// (and read_only/super_read_only) at runtime.
+	DbTypeAsync = "async"
 
 	// ---------------------------------------------------------------------------
 	// Output format strings — passed in the output field of the request.
@@ -90,6 +95,11 @@ const (
 	// cache can spike during long write transactions, so a lower ceiling reserves
 	// headroom to avoid OOM kills.
 	InnoDBPctValueGR = 0.70
+
+	// InnoDBPctValueAsync async has no certification cache / GCache / GCS
+	// structure, so more memory reaches InnoDB than GR. We keep the conservative
+	// (replica-safe) ceiling so a node is safe while applying relay logs.
+	InnoDBPctValueAsync = 0.82
 
 	// GroupRepGCSCacheMemStructureCost is a fixed 50 MiB reserved for the Group
 	// Replication message-cache data structure itself. It is deducted from MySQL
@@ -113,6 +123,10 @@ const (
 	// as the evaluation threshold. Set lower than PXC because GR needs more headroom
 	// for certification and message caches.
 	MinLimitGR = 0.40
+
+	// MinLimitAsync: BP floor for async — evaluation threshold as a fraction of
+	// total dimension memory. Higher than GR because no cluster caches compete.
+	MinLimitAsync = 0.52
 
 	// MemoryFreeMinimumLimit reserves 2% of total MySQL memory, never allocated to
 	// any structure, as a safety margin for allocator overhead and OS paging.
@@ -139,6 +153,17 @@ const (
 	// GCSConnWeight is the assumed per-connection cost in bytes for the GR message
 	// cache. Multiplied by max_connections to estimate total GCS memory demand.
 	GCSConnWeight = 10
+
+	// ---------------------------------------------------------------------------
+	// Asynchronous replication
+	// ---------------------------------------------------------------------------
+
+	// --- Async binlog cache size by load type (per connection) ---
+	// Check Binlog_cache_use and Binlog_cache_disk_use  for tuning
+	BinlogCacheSizeRead       = "32768"  //  32 KiB — mostly reads
+	BinlogCacheSizeLightWrite = "131072" // 128 KiB — light OLTP
+	BinlogCacheSizeHeavyOLTP  = "262144" // 256 KiB — heavy OLTP
+	BinlogCacheSizeHeavyWrite = "524288" // 512 KiB — bulk write
 
 	// ---------------------------------------------------------------------------
 	// Auto-scale stepping increments (used when dimension.id = 998)

--- a/src/mysqloperatorcalculator/configurator.go
+++ b/src/mysqloperatorcalculator/configurator.go
@@ -117,9 +117,12 @@ func (c *Configurator) Init(r ConfigurationRequest, fam map[string]Family, conf 
 	}
 
 	c.reference.loadFactor = loadConnectionFactor
-	if c.request.DBType == DbTypePXC {
+	switch c.request.DBType {
+	case DbTypePXC:
 		c.reference.idealBufferPoolDIm = int64(c.reference.memoryMySQL * InnoDBPctValuePXC)
-	} else {
+	case DbTypeAsync:
+		c.reference.idealBufferPoolDIm = int64(c.reference.memoryMySQL * InnoDBPctValueAsync)
+	default:
 		c.reference.idealBufferPoolDIm = int64(c.reference.memoryMySQL * InnoDBPctValueGR)
 	}
 	c.reference.gcacheLoad = c.getGcacheLoad()
@@ -185,6 +188,10 @@ func (c *Configurator) ProcessRequest() map[string]Family {
 			c.families["mysql"].Groups["configuration_groupReplication"] = group
 		}
 
+		if c.request.DBType == DbTypeAsync {
+			c.getAsyncParameters()
+		}
+
 		// Before returning the values we want tore recover any left over from the memory and assign back to the buffer pool by a %
 		c.getInnodbBufferPool(true)
 
@@ -194,6 +201,70 @@ func (c *Configurator) ProcessRequest() map[string]Family {
 	}
 
 	return c.filterByMySQLVersion()
+}
+
+func (c *Configurator) getAsyncParameters() {
+	// --- server group: binlog behaviour ---
+	serverGroup := c.families["mysql"].Groups["configuration_server"]
+
+	// binlog_row_image: MINIMAL only for mostly-reads; FULL otherwise (safe for downstream GR consumers and conflict detection).
+	binlogRowImage := serverGroup.Parameters["binlog_row_image"]
+	binlogRowImage.Value = c.loadValues([4]string{"MINIMAL", "FULL", "FULL", "FULL"})
+	serverGroup.Parameters["binlog_row_image"] = binlogRowImage
+
+	// binlog_expire_logs_seconds: shrink retention on heavy write to bound disk.
+	binlogExpireSec := serverGroup.Parameters["binlog_expire_logs_seconds"]
+	binlogExpireSec.Value = c.loadValues([4]string{"604800", "604800", "432000", "259200"})
+	serverGroup.Parameters["binlog_expire_logs_seconds"] = binlogExpireSec
+	c.families["mysql"].Groups["configuration_server"] = serverGroup
+
+	// --- innodb group: durability. Any node may be promoted, so require 1. ---
+	innoDBGroup := c.families["mysql"].Groups["configuration_innodb"]
+	FlushLogTrxCommit := innoDBGroup.Parameters["innodb_flush_log_at_trx_commit"]
+	FlushLogTrxCommit.Value = "1"
+	innoDBGroup.Parameters["innodb_flush_log_at_trx_commit"] = FlushLogTrxCommit
+	c.families["mysql"].Groups["configuration_innodb"] = innoDBGroup
+
+	// --- async group: relay/apply tuning ---
+	asyncGroup := c.families["mysql"].Groups["configuration_async"]
+
+	// sync_relay_log: crash-safe (1) on write-heavy; performance (0) on read-heavy.
+	syncRelayLog := asyncGroup.Parameters["sync_relay_log"]
+	{
+		defaultInt, err := strconv.Atoi(syncRelayLog.Default)
+		if err != nil {
+			log.Error(err)
+			defaultInt = 10000
+		}
+		syncRelayLog.Value = c.loadValues([4]string{syncRelayLog.Default, syncRelayLog.Default,
+			strconv.Itoa(defaultInt / 2),
+			strconv.Itoa(defaultInt / 3)})
+	}
+	asyncGroup.Parameters["sync_relay_log"] = syncRelayLog
+
+	// replica_net_timeout: base 60s, scaled up with load.
+	replicaNetTimeout := asyncGroup.Parameters["replica_net_timeout"]
+	replicaNetTimeout.Value = strconv.Itoa(int(math.Ceil(60 * (1 + float64(c.reference.loadFactor)))))
+	asyncGroup.Parameters["replica_net_timeout"] = replicaNetTimeout
+
+	// replica_checkpoint_period: scaled to match the higher writes.
+	replicaCheckpointPeriod := asyncGroup.Parameters["replica_checkpoint_period"]
+	{
+		defaultInt, err := strconv.Atoi(replicaCheckpointPeriod.Default)
+		if err != nil {
+			log.Error(err)
+			defaultInt = 300
+		}
+
+		replicaCheckpointPeriod.Value = c.loadValues([4]string{
+			strconv.Itoa(defaultInt),
+			strconv.Itoa(defaultInt),
+			strconv.Itoa(int(float64(defaultInt) * 0.80)),
+			strconv.Itoa(int(float64(defaultInt) * 0.70))})
+	}
+	asyncGroup.Parameters["replica_checkpoint_period"] = replicaCheckpointPeriod
+
+	c.families["mysql"].Groups["configuration_async"] = asyncGroup
 }
 
 func (c *Configurator) filterByMySQLVersion() map[string]Family {
@@ -284,8 +355,10 @@ func (c *Configurator) getGcache() {
 
 func (c *Configurator) getConnectionBuffers() {
 	group := c.families["mysql"].Groups["configuration_connection"]
-	//group.Parameters["binlog_cache_size"] = c.paramBinlogCacheSize(group.Parameters["binlog_cache_size"])
-	//group.Parameters["binlog_stmt_cache_size"] = c.paramBinlogCacheSize(group.Parameters["binlog_stmt_cache_size"])
+	if c.request.DBType == DbTypeAsync {
+		group.Parameters["binlog_cache_size"] = c.paramBinlogCacheSize(group.Parameters["binlog_cache_size"])
+		group.Parameters["binlog_stmt_cache_size"] = c.paramBinlogCacheSize(group.Parameters["binlog_stmt_cache_size"])
+	}
 	group.Parameters["join_buffer_size"] = c.paramJoinBuffer(group.Parameters["join_buffer_size"])
 	group.Parameters["read_rnd_buffer_size"] = c.paramReadRndBuffer(group.Parameters["read_rnd_buffer_size"])
 	group.Parameters["sort_buffer_size"] = c.paramSortBuffer(group.Parameters["sort_buffer_size"])
@@ -457,14 +530,18 @@ func (c *Configurator) paramInnoDBAdaptiveHashIndex(parameter Parameter) Paramet
 }
 
 func (c *Configurator) paramInnoDBBufferPool(parameter Parameter, final bool) Parameter {
-	bufferPollPct := InnoDBPctValueGR
-	if c.request.DBType == "pxc" {
+	bufferPollPct := 1.0
+	switch c.request.DBType {
+	case DbTypePXC:
 		bufferPollPct = InnoDBPctValuePXC
+	case DbTypeAsync:
+		bufferPollPct = InnoDBPctValueAsync
+	case DbTypeGroupReplication:
+		bufferPollPct = InnoDBPctValueGR
 	}
 
 	if !final {
 		bufferPool := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
-		//bufferPoolSubstract := int64(math.Floor(float64(c.reference.memoryLeftover) * bufferPollPct))
 
 		parameter.Value = strconv.FormatInt(bufferPool, 10)
 		c.reference.innoDBbpSize = bufferPool
@@ -485,10 +562,20 @@ func (c *Configurator) paramInnoDBBufferPool(parameter Parameter, final bool) Pa
 			c.reference.memoryLeftover = 0
 
 			// Enforce minimum buffer pool floor to prevent going dangerously low
-			minPct := MinLimitGR
-			if c.request.DBType == "pxc" {
+			//minPct := MinLimitGR
+			//if c.request.DBType == "pxc" {
+			//	minPct = MinLimitPXC
+			//}
+			minPct := 1.0
+			switch c.request.DBType {
+			case DbTypePXC:
 				minPct = MinLimitPXC
+			case DbTypeAsync:
+				minPct = MinLimitAsync
+			case DbTypeGroupReplication:
+				minPct = MinLimitGR
 			}
+
 			minBufferPool := int64(c.reference.memoryMySQL * minPct)
 			if bufferPool < minBufferPool {
 				bufferPool = minBufferPool
@@ -962,11 +1049,16 @@ func (c *Configurator) paramServerThreadCacheSize(parameter Parameter) Parameter
 
 func (c *Configurator) FillResponseMessage(pct float64, msg ResponseMessage, b bytes.Buffer, DBType string) (ResponseMessage, bool) {
 	overUtilizing := false
-	minlimit := float64(MinLimitPXC)
-	if DBType == "group_replication" {
-		minlimit = float64(MinLimitGR)
-	}
+	minlimit := 0.30
 
+	switch DBType {
+	case DbTypeGroupReplication:
+		minlimit = float64(MinLimitGR)
+	case DbTypeAsync:
+		minlimit = float64(MinLimitAsync)
+	case DbTypePXC:
+		minlimit = float64(MinLimitPXC)
+	}
 	// Not used anymore the memory leftover is managed dealing with the Bufferpool size
 	//if c.reference.memoryLeftover < 0 {
 	//	overUtilizing = true
@@ -1016,6 +1108,7 @@ func (c *Configurator) paramReplicaParallelWorkers(parameter Parameter) Paramete
 			value = proposedWorkers
 		}
 	}
+
 	parameter.Value = strconv.Itoa(value)
 	return parameter
 

--- a/src/mysqloperatorcalculator/configurator.go
+++ b/src/mysqloperatorcalculator/configurator.go
@@ -370,22 +370,22 @@ func (c *Configurator) getConnectionBuffers() {
 }
 
 func (c *Configurator) paramBinlogCacheSize(inParameter Parameter) Parameter {
-	inParameter.Value = c.loadValues([4]string{"32768", "131072", "262144", "358400"})
+	inParameter.Value = c.loadValues([4]string{BinlogCacheSizeRead, BinlogCacheSizeLightWrite, BinlogCacheSizeHeavyOLTP, BinlogCacheSizeHeavyWrite})
 	return inParameter
 }
 
 func (c *Configurator) paramJoinBuffer(inParameter Parameter) Parameter {
-	inParameter.Value = c.loadValues([4]string{"262144", "524288", "1048576", "1048576"})
+	inParameter.Value = c.loadValues([4]string{JoinBufferSizeRead, JoinBufferSizeLightWrite, JoinBufferSizeHeavyOLTP, JoinBufferSizeHeavyWrite})
 	return inParameter
 }
 
 func (c *Configurator) paramReadRndBuffer(inParameter Parameter) Parameter {
-	inParameter.Value = c.loadValues([4]string{"262144", "393216", "707788", "707788"})
+	inParameter.Value = c.loadValues([4]string{ReadRndBufferSizeRead, ReadRndBufferSizeLightWrite, ReadRndBufferSizeHeavyOLTP, ReadRndBufferSizeHeavyWrite})
 	return inParameter
 }
 
 func (c *Configurator) paramSortBuffer(inParameter Parameter) Parameter {
-	inParameter.Value = c.loadValues([4]string{"262144", "524288", "1572864", "2097152"})
+	inParameter.Value = c.loadValues([4]string{SortBufferSizeRead, SortBufferSizeLightWrite, SortBufferSizeHeavyOLTP, SortBufferSizeHeavyWrite})
 	return inParameter
 }
 
@@ -562,10 +562,6 @@ func (c *Configurator) paramInnoDBBufferPool(parameter Parameter, final bool) Pa
 			c.reference.memoryLeftover = 0
 
 			// Enforce minimum buffer pool floor to prevent going dangerously low
-			//minPct := MinLimitGR
-			//if c.request.DBType == "pxc" {
-			//	minPct = MinLimitPXC
-			//}
 			minPct := 1.0
 			switch c.request.DBType {
 			case DbTypePXC:
@@ -829,6 +825,7 @@ func (c *Configurator) EvaluateResources(responseMsg ResponseMessage) (ResponseM
 	var b bytes.Buffer
 
 	// Fprintf is heavily optimized for constructing complex text blocks and eliminates numerous temporary strings
+	fmt.Fprintf(&b, "\n\nCluster Type    = %s\n", c.request.DBType)
 	fmt.Fprintf(&b, "\n\nTot Memory Bytes    = %.0f\n", c.reference.memory)
 	fmt.Fprintf(&b, "Tot CPU                 = %d\n", c.reference.cpus)
 	fmt.Fprintf(&b, "Tot Connections         = %d\n\n", c.reference.connections)

--- a/src/mysqloperatorcalculator/mysqloperatorcalculator.go
+++ b/src/mysqloperatorcalculator/mysqloperatorcalculator.go
@@ -46,8 +46,10 @@ func (moc *MysqlOperatorCalculator) GetCalculate() (error, ResponseMessage, map[
 		return fmt.Errorf("Open dimension request missing CPU OR Memory value CPU: %d, Memory %s", ConfRequest.Dimension.Cpu, ConfRequest.Dimension.Memory), responseMsg, families
 	}
 
-	if ConfRequest.DBType != DbTypePXC && ConfRequest.DBType != DbTypeGroupReplication {
-		return fmt.Errorf("DB Type is not correct. Supported Types are: %s, %s", DbTypePXC, DbTypeGroupReplication), responseMsg, families
+	if ConfRequest.DBType != DbTypePXC &&
+		ConfRequest.DBType != DbTypeGroupReplication &&
+		ConfRequest.DBType != DbTypeAsync {
+		return fmt.Errorf("DB Type is not correct. Supported Types are: %s, %s, %s", DbTypePXC, DbTypeGroupReplication, DbTypeAsync), responseMsg, families
 	}
 
 	// If calculating by connection (id = 998) and valid number for connection


### PR DESCRIPTION
Constants.go
  Added DbTypeAsync = "async".
  Added InnoDBPctValueAsync = 0.82 — no cluster cache structures, but
    conservative ceiling to keep the node safe while applying relay logs.
  Added MinLimitAsync = 0.52 — evaluation floor, higher than GR because
    no certification/GCS caches compete for memory.
  Added BinlogCacheSize* constants for per-load-type binlog cache sizing.
Configuration.go
  Registered "async" in conf.DBType so /supported exposes it.
  Added async-specific parameters in Family.Init() for DbTypeAsync:
    connection group: binlog_cache_size, binlog_stmt_cache_size
    server group:     binlog_format (ROW), binlog_row_image (FULL),
                      binlog_expire_logs_seconds, gtid_mode (ON),
                      enforce_gtid_consistency (ON)
    new configuration_async group: relay_log_space_limit, sync_relay_log,
                                   replica_net_timeout, replica_checkpoint_period
configurator.go
  Init(): idealBufferPoolDIm selection now uses switch on DBType;
    DbTypeAsync maps to InnoDBPctValueAsync.
  ProcessRequest(): calls getAsyncParameters() for async requests.
  getAsyncParameters() (new): adjusts binlog_row_image and
    binlog_expire_logs_seconds by load type; forces
    innodb_flush_log_at_trx_commit=1 (any node may be promoted);
    scales sync_relay_log, replica_net_timeout, replica_checkpoint_period
    against loadFactor.
  getConnectionBuffers(): enables binlog_cache_size / binlog_stmt_cache_size
    sizing for async (was commented out for PXC/GR paths).
  paramInnoDBBufferPool(): if/else replaced with switch; async uses
    InnoDBPctValueAsync and MinLimitAsync floors.
  FillResponseMessage(): if/else replaced with switch; async uses MinLimitAsync.
mysqloperatorcalculator.go
  DBType validation extended to accept DbTypeAsync; error message updated.