### PR TITLE
Feature/mysql dedicated mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,42 @@ All parameters are passed as a JSON payload to the `/calculator` endpoint or via
 | `mysqlversion.minor` | `int` | **Yes** | MySQL minor version (`0` … `4`) |
 | `mysqlversion.patch` | `int` | **Yes** | Patch version |
 | `providercostpct` | `float` | No | Platform overhead (e.g., `0.15` = 15%). Default `0`. |
+| `mysqldedicated` | `bool` | No | When `true`, the calculator runs in **MySQL Dedicated** mode (see below). Default `false`. |
 
 > **💡 Important Notes:**
 > - Connection values below **50** are automatically raised to `50`.
 > - If `connections` is set to `0`, the calculator iteratively increments the connection count until resources become saturated, returning the highest viable value.
 > - If `dimension.id` is set to `998`, the request is **connection‑driven**. The calculator will automatically pick the smallest pre‑defined dimension that can comfortably handle the requested connection count.
+
+---
+
+## 🖥️ MySQL Dedicated Mode
+
+Setting `mysqldedicated: true` tells the calculator that **MySQL is the only workload on the node** — there is no HAProxy sidecar and no PMM monitoring container. This has three effects:
+
+1. **Full resource allocation to MySQL.** In an open-dimension request (`dimension.id = 999`), 100% of the specified CPU and memory are assigned directly to the MySQL container instead of being split between MySQL, proxy, and monitor.
+2. **Proxy and monitor are not calculated.** The `getProbesAndResources` calls for `FamilyTypeProxy` and `FamilyTypeMonitor` are skipped entirely.
+3. **Proxy and monitor families are absent from the response.** The `proxy` and `monitor` keys are removed from the `answer` block, so only `mysql` is returned.
+
+> **When to use it:** standalone MySQL instances, single-container deployments, or scenarios where ProxySQL / HAProxy and PMM run on separate nodes or are not used at all.
+
+**HTTP example:**
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{
+  "output": "json",
+  "dbtype": "group_replication",
+  "dimension": { "id": 999, "cpu": 8000, "memory": "16G" },
+  "loadtype": { "id": 2 },
+  "connections": 500,
+  "mysqlversion": { "major": 8, "minor": 4, "patch": 8 },
+  "mysqldedicated": true
+}' http://127.0.0.1:8080/calculator
+```
+
+**Go module example:**
+```go
+myRequest.MySQLDedicated = true
+```
 
 ---
 
@@ -666,6 +697,7 @@ All tuning knobs are defined in `src/mysqloperatorcalculator/Constants.go`. The 
 |:---|:---:|:---|
 | `GroupRepGCSCacheMemStructureCost` | `52428800` (50 MiB) | Fixed overhead for the GR message-cache data structure, deducted from MySQL memory before buffer pool sizing. Separate from the per-connection cost. |
 | `GCSConnWeight` | `10` | Bytes per connection assumed for the GR message cache. Multiplied by `max_connections` to estimate total GCS memory demand. |
+| `GCSCacheMemoryImpactPctBuferPool` | `3.2` | Multiplier applied to the calculated GCS cache footprint before it is deducted from `memoryLeftover`. A plain subtraction of `group_replication_message_cache_size` understates the true buffer pool pressure because the Performance Schema reports lower utilization than the actual resident set. Multiplying by 3.2 reserves additional headroom so the InnoDB buffer pool remains stable even when GCS memory usage spikes above what the PS reports. |
 
 ### Binlog cache sizing (async only)
 
@@ -866,7 +898,7 @@ if memoryLeftover < 0:
     bufferPool  = max(bufferPool, memoryMySQL × MinLimit)  # enforce floor
 ```
 
-`CalculateReturnBytes` interpolates the recovery fraction linearly between 20% (≤ 300 MiB leftover — cautious, preserve the margin) and 85% (≥ 2 GiB leftover — large surplus, return most of it to InnoDB).
+`CalculateReturnBytes` interpolates the recovery fraction linearly between 20% (≤ 300 MiB leftover — cautious, preserve the margin) and 80% (≥ 2 GiB leftover — large surplus, return most of it to InnoDB). The ceiling was lowered from 85% to 80% to leave a slightly larger unconditional safety margin for allocator and OS overhead on large instances.
 
 ### Phase 8 — Kubernetes Resources and Probes
 

--- a/src/example/example.go
+++ b/src/example/example.go
@@ -35,6 +35,7 @@ func testGetconfiguration(moc MO.MysqlOperatorCalculator) {
 	var err error
 
 	myRequest.LoadType = MO.LoadType{Id: MO.LoadTypeSomeWrites}
+	myRequest.MySQLDedicated = true
 
 	// Setting the dimension using literal values
 	myRequest.Dimension = MO.Dimension{Id: MO.DimensionOpen, Cpu: 4000, Memory: "2.5G"}
@@ -46,8 +47,8 @@ func testGetconfiguration(moc MO.MysqlOperatorCalculator) {
 		log.Fatalf("Memory conversion error: %v\n", err)
 	}
 
-	myRequest.DBType = MO.DbTypeGroupReplication  // "pxc" or "group_replication"
-	myRequest.Output = MO.ResultOutputFormatHuman // "human" or "json"
+	myRequest.DBType = MO.DbTypeGroupReplication // "pxc" or "group_replication"
+	myRequest.Output = MO.ResultOutputFormatJson // "human" or "json"
 	myRequest.Connections = 3000
 	myRequest.Mysqlversion = MO.Version{Major: 8, Minor: 4, Patch: 8}
 	myRequest.ProviderCostPct = 0.12

--- a/src/mysqloperatorcalculator/Configuration.go
+++ b/src/mysqloperatorcalculator/Configuration.go
@@ -53,6 +53,7 @@ type Configuration struct {
 	Output          []string      `json:"output"`
 	Mysqlversions   MySQLVersions `json:"mysqlversions"`
 	ProviderCostPct float64       `json:"providercostpct"`
+	MySQLDedicated  bool          `json:"mysqldedicated"`
 }
 
 type ConfigurationRequest struct {
@@ -63,6 +64,7 @@ type ConfigurationRequest struct {
 	Output          string    `json:"output"`
 	Mysqlversion    Version   `json:"mysqlversion"`
 	ProviderCostPct float64   `json:"providercostpct"`
+	MySQLDedicated  bool      `json:"mysqldedicated"`
 }
 
 type Dimension struct {
@@ -469,6 +471,13 @@ func (conf *Configuration) CalculateOpenDimension(dimension Dimension) Dimension
 		calcDimension := conf.getDimensionForFreeCalculation(dimension)
 
 		// Calculate ratios
+		if conf.MySQLDedicated {
+			dimension.MysqlMemory = dimension.MemoryBytes * 1
+			dimension.MysqlCpu = int(float64(dimension.Cpu) * 1)
+
+			return dimension
+
+		}
 		ratioMysqlCpu := float64(calcDimension.MysqlCpu) / float64(calcDimension.Cpu)
 		ratioProxyCpu := float64(calcDimension.ProxyCpu) / float64(calcDimension.Cpu)
 		ratioPmmCpu := float64(calcDimension.PmmCpu) / float64(calcDimension.Cpu)

--- a/src/mysqloperatorcalculator/configurator.go
+++ b/src/mysqloperatorcalculator/configurator.go
@@ -196,8 +196,11 @@ func (c *Configurator) ProcessRequest() map[string]Family {
 		c.getInnodbBufferPool(true)
 
 		c.getProbesAndResources(FamilyTypeMysql)
-		c.getProbesAndResources(FamilyTypeProxy)
-		c.getProbesAndResources(FamilyTypeMonitor)
+		// If we are not in a MySQL dedicate server then calculate all
+		if !c.request.MySQLDedicated {
+			c.getProbesAndResources(FamilyTypeProxy)
+			c.getProbesAndResources(FamilyTypeMonitor)
+		}
 	}
 
 	return c.filterByMySQLVersion()
@@ -829,6 +832,10 @@ func (c *Configurator) EvaluateResources(responseMsg ResponseMessage) (ResponseM
 	fmt.Fprintf(&b, "\n\nTot Memory Bytes    = %.0f\n", c.reference.memory)
 	fmt.Fprintf(&b, "Tot CPU                 = %d\n", c.reference.cpus)
 	fmt.Fprintf(&b, "Tot Connections         = %d\n\n", c.reference.connections)
+
+	if c.request.MySQLDedicated {
+		fmt.Fprintf(&b, "MySQL Dedicated Instance activated  \n")
+	}
 
 	fmt.Fprintf(&b, "memory assign to mysql Bytes   = %.0f\n", c.reference.memoryMySQL)
 	fmt.Fprintf(&b, "memory assign to Proxy Bytes   = %.0f\n", c.reference.memoryProxy)

--- a/src/mysqloperatorcalculator/configurator_test.go
+++ b/src/mysqloperatorcalculator/configurator_test.go
@@ -47,7 +47,7 @@ func TestCalculateReturnBytes_AboveMaxThreshold(t *testing.T) {
 	c := &Configurator{reference: &references{}}
 	input := int64(2048 * testMB)
 	got := c.CalculateReturnBytes(input)
-	want := int64(float64(input) * 0.85)
+	want := int64(float64(input) * 0.80)
 	if got != want {
 		t.Errorf("CalculateReturnBytes(2048MB) = %d, want %d", got, want)
 	}
@@ -57,9 +57,9 @@ func TestCalculateReturnBytes_Interpolated(t *testing.T) {
 	c := &Configurator{reference: &references{}}
 	input := int64(1024 * testMB) // 1GB: midpoint between 300MB and 2GB thresholds
 	got := c.CalculateReturnBytes(input)
-	// Should be between 20% and 85%
+	// Should be between 20% and 80%
 	low := int64(float64(input) * 0.20)
-	high := int64(float64(input) * 0.85)
+	high := int64(float64(input) * 0.80)
 	if got < low || got > high {
 		t.Errorf("CalculateReturnBytes(1GB) = %d, want value in [%d, %d]", got, low, high)
 	}

--- a/src/mysqloperatorcalculator/mysqloperatorcalculator.go
+++ b/src/mysqloperatorcalculator/mysqloperatorcalculator.go
@@ -21,6 +21,7 @@ type MysqlOperatorCalculator struct {
 func (moc *MysqlOperatorCalculator) Init(inR ConfigurationRequest, conf Configuration) ConfigurationRequest {
 	moc.IncomingRequest = inR
 	moc.Conf = conf
+	moc.Conf.MySQLDedicated = inR.MySQLDedicated
 	if moc.IncomingRequest.ProviderCostPct > 0 {
 		moc.adjustResourcesByProvider()
 	}
@@ -106,6 +107,12 @@ func (moc *MysqlOperatorCalculator) GetCalculate() (error, ResponseMessage, map[
 		message.MText += fmt.Sprintf("\n!!!! Connections recalculated Original: %d New Value %d plus additional 2 for administrative use !!!\n\n", originalConnections, moc.IncomingRequest.Connections)
 		message.MName = message.GetMessageText(ConnectionRecalculated)
 		message.MType = ConnectionRecalculated
+	}
+
+	// If we are in MySQL dedicated instance then remove proxy and monitor
+	if moc.IncomingRequest.MySQLDedicated {
+		delete(Families, FamilyTypeProxy)
+		delete(Families, FamilyTypeMonitor)
 	}
 
 	return calcErr, message, Families

--- a/src/server.go
+++ b/src/server.go
@@ -235,6 +235,7 @@ func ReturnResponse(writer http.ResponseWriter, request *http.Request, ConfReque
 	var b bytes.Buffer
 	var err error
 	var moc MO.MysqlOperatorCalculator
+
 	if ConfRequest.Output == "json" {
 		b, err = moc.GetJSONOutput(message, ConfRequest, families)
 	} else {


### PR DESCRIPTION
## Summary
- **MySQL Dedicated mode** (`mysqldedicated: true`): when set, 100% of the requested CPU/memory is assigned to MySQL — no proxy/monitor split. Proxy and monitor are neither calculated nor returned in the response. Useful for standalone MySQL instances or deployments where HAProxy/PMM run elsewhere.
- **`GCSCacheMemoryImpactPctBuferPool = 3.2`**: the GCS cache footprint deducted from `memoryLeftover` is now multiplied by 3.2× instead of taken at face value. Performance Schema reports lower GCS utilization than the actual resident set, so a plain subtraction leaves the InnoDB buffer pool with less headroom than expected under load.
- **`CalculateReturnBytes` max recovery fraction lowered from 85% → 80%**: preserves a slightly larger unconditional safety margin for allocator overhead on large instances.
- README updated to document all three changes, including a new _MySQL Dedicated Mode_ section with HTTP and Go module examples.
## Test plan
- [x] Run `go test ./...` — confirm no regressions.
- [x] Send a `mysqldedicated: true` request to `/calculator` and verify the response contains only the `mysql` family.
- [x] Send a `mysqldedicated: false` (default) request and verify `proxy` and `monitor` are still present.
- [x] Verify the example in `src/example/example.go` compiles and produces valid output.